### PR TITLE
fix warnings

### DIFF
--- a/comb_spec_searcher/rule_db.py
+++ b/comb_spec_searcher/rule_db.py
@@ -4,7 +4,8 @@ A database for rules.
 Use to keep track of all batch rules made by strategies. Each rule comes with
 an explanantion.
 """
-from collections import Iterable, defaultdict
+from collections import defaultdict
+from collections.abc import Iterable
 
 
 class RuleDB(object):

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -7,7 +7,7 @@ types supported for a rule a -> b_1, b_2, ..., b_k are
     - cartesian product: f(a) = f(b_1) * f(b_2) * ... * f(b_k)
 '''
 import warnings
-from collections import Iterable
+from collections.abc import Iterable
 from functools import partial
 
 


### PR DESCRIPTION
I just fixed this warning about python 3.8
```
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```