### PR TITLE
use forward equivalence for other constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix the dict method of Info so that it saves all the attributes.
 
+### Changed
+- If `forward_equivalence` is `False`, then if the constructor is one of
+  `equiv`, `disjoint`, or `disjoint` the rule will be treated with forward
+  equivalence.
+
 ## [0.3.0] - 2019-12-16
 ### Added
 - `ProofTree.generate_objects_of_length()` implements an algorithm for

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -393,7 +393,8 @@ class CombinatorialSpecificationSearcher(object):
                          repr(self.classdb.get_class(end)) + "\n" +
                          "formal step:" + explanation)
                 logger.debug(error, extra=self.logger_kwargs)
-        if self.forward_equivalence:
+        if (self.forward_equivalence or
+                constructor not in ('equiv', 'disjoint', 'cartesian')):
             reverse_rule = end, (start,)
             if self.ruledb.contains(*reverse_rule):
                 raise ValueError(("Same equivalent rule found forward and "


### PR DESCRIPTION
This is a short one line fix that allows the flexibility to use forward equivalence for certain strategies. This change ensures that even if `forward_equivalence` is set to `False`, then if the constructor is not one of `equiv`, `disjoint`, or `disjoint` the rule will be treated with forward equivalence.