### PR TITLE
fix is expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The `CombinatorialSpecification.auto_seach()` only uses keyword arguments.
 
+### Fixed
+- Fix the `is_expanded` function to check for inferral and initial expansion
+
 ## [0.4.0] - 2020-02-20
 ### Fixed
 - Fix the dict method of Info so that it saves all the attributes.

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -539,9 +539,9 @@ class CombinatorialSpecificationSearcher():
         """Return True if a combinatorial class has been expanded by all
         strategies."""
         number_times_expanded = self.classdb.number_times_expanded(label)
-        if number_times_expanded >= len(self.strategy_generators):
-            return True
-        return False
+        return (number_times_expanded >= len(self.strategy_generators) and
+                self.classdb.is_inferral_expanded(label) and
+                self.classdb.is_initial_expanded(label))
 
     def _symmetry_expand(self, comb_class):
         """Add symmetries of combinatorial class to the database."""


### PR DESCRIPTION
In its current state, the is_expanded function only returns True if the
class was expanded with the expansion strategy and to not account of
inferral of initial strategy. We are fixing that.