### PR TITLE
Fix generation bug

### DIFF
--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -89,9 +89,10 @@ class CombinatorialSpecification(
         self, comb_class: CombinatorialClassType
     ) -> AbstractRule[CombinatorialClassType, CombinatorialObjectType]:
         """Return the rule with comb class on the left."""
-        if comb_class.is_empty():
-            empty_strat = EmptyStrategy()
-            self.rules_dict[comb_class] = empty_strat(comb_class)
+        if comb_class not in self.rules_dict:
+            if comb_class.is_empty():
+                empty_strat = EmptyStrategy()
+                self.rules_dict[comb_class] = empty_strat(comb_class)
         return self.rules_dict[comb_class]
 
     @property

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -253,7 +253,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         return self._constructor
 
     def backward_map(
-        self, objs: Tuple[CombinatorialObjectType, ...]
+        self, objs: Tuple[Optional[CombinatorialObjectType], ...]
     ) -> CombinatorialObjectType:
         """
         This encodes the backward map of the underlying bijection that the
@@ -263,7 +263,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
 
     def forward_map(
         self, obj: CombinatorialObjectType
-    ) -> Tuple[CombinatorialObjectType, ...]:
+    ) -> Tuple[Optional[CombinatorialObjectType], ...]:
         """
         This encodes the forward map of the underlying bijection that the
         strategy implies.
@@ -376,7 +376,7 @@ class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
         )
 
     def backward_map(
-        self, objs: Tuple[CombinatorialObjectType, ...]
+        self, objs: Tuple[Optional[CombinatorialObjectType], ...]
     ) -> CombinatorialObjectType:
         actual_objs = tuple(
             objs[0] if i == self.child_idx else None
@@ -388,7 +388,7 @@ class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
 
     def forward_map(
         self, obj: CombinatorialObjectType
-    ) -> Tuple[CombinatorialObjectType, ...]:
+    ) -> Tuple[Optional[CombinatorialObjectType], ...]:
         return (
             self.strategy.forward_map(self.comb_class, obj, self.actual_children)[
                 self.child_idx
@@ -430,19 +430,19 @@ class EquivalencePathRule(Rule[CombinatorialClassType, CombinatorialObjectType])
         return eqv_path_rules
 
     def backward_map(
-        self, objs: Tuple[CombinatorialObjectType, ...]
+        self, objs: Tuple[Optional[CombinatorialObjectType], ...]
     ) -> CombinatorialObjectType:
-        res = objs
+        res = cast(Tuple[CombinatorialObjectType], objs)
         for rule in reversed(self.rules):
             res = (rule.backward_map(res),)
         return res[0]
 
     def forward_map(
         self, obj: CombinatorialObjectType
-    ) -> Tuple[CombinatorialObjectType, ...]:
-        res = obj
+    ) -> Tuple[Optional[CombinatorialObjectType], ...]:
+        res = cast(CombinatorialObjectType, obj)
         for rule in reversed(self.rules):
-            res = rule.forward_map(res)[0]
+            res = cast(CombinatorialObjectType, rule.forward_map(res)[0])
         return (res,)
 
     def __eq__(self, other) -> bool:
@@ -503,15 +503,17 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
         return "reverse of '{}'".format(self.strategy.formal_step())
 
     def backward_map(
-        self, objs: Tuple[CombinatorialObjectType, ...]
+        self, objs: Tuple[Optional[CombinatorialObjectType], ...]
     ) -> CombinatorialObjectType:
-        return self.strategy.forward_map(self.children[0], objs[0], (self.comb_class,))[
-            0
-        ]
+        obj = cast(CombinatorialObjectType, objs[0])
+        return cast(
+            CombinatorialObjectType,
+            self.strategy.forward_map(self.children[0], obj, (self.comb_class,))[0],
+        )
 
     def forward_map(
         self, obj: CombinatorialObjectType
-    ) -> Tuple[CombinatorialObjectType, ...]:
+    ) -> Tuple[Optional[CombinatorialObjectType], ...]:
         return (
             self.strategy.backward_map(self.children[0], (obj,), (self.comb_class,)),
         )

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -375,6 +375,17 @@ class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
             self.strategy.formal_step(), self.child_idx
         )
 
+    def backward_map(
+        self, objs: Tuple[CombinatorialObjectType, ...]
+    ) -> CombinatorialObjectType:
+        actual_objs = tuple(
+            objs[0] if i == self.child_idx else None
+            for i in range(len(self.actual_children))
+        )
+        return self.strategy.backward_map(
+            self.comb_class, actual_objs, self.actual_children
+        )
+
     def forward_map(
         self, obj: CombinatorialObjectType
     ) -> Tuple[CombinatorialObjectType, ...]:

--- a/comb_spec_searcher/strategies/strategy.py
+++ b/comb_spec_searcher/strategies/strategy.py
@@ -50,7 +50,7 @@ AtomStrategy, relying on CombinatorialClass methods.
 """
 import abc
 from importlib import import_module
-from typing import TYPE_CHECKING, Generic, Iterator, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Generic, Iterator, Optional, Tuple, Type, Union, cast
 
 from sympy import Expr, Integer, var
 
@@ -270,7 +270,7 @@ class Strategy(AbstractStrategy[CombinatorialClassType, CombinatorialObjectType]
     def backward_map(
         self,
         comb_class: CombinatorialClassType,
-        objs: Tuple[CombinatorialObjectType, ...],
+        objs: Tuple[Optional[CombinatorialObjectType], ...],
         children: Optional[Tuple[CombinatorialClassType, ...]] = None,
     ) -> CombinatorialObjectType:
         """
@@ -286,7 +286,7 @@ class Strategy(AbstractStrategy[CombinatorialClassType, CombinatorialObjectType]
         comb_class: CombinatorialClassType,
         obj: CombinatorialObjectType,
         children: Optional[Tuple[CombinatorialClassType, ...]] = None,
-    ) -> Tuple[CombinatorialObjectType, ...]:
+    ) -> Tuple[Optional[CombinatorialObjectType], ...]:
         """
         The backward direction of the underlying bijection used for object
         generation and sampling.
@@ -369,12 +369,12 @@ class DisjointUnionStrategy(Strategy[CombinatorialClassType, CombinatorialObject
         return DisjointUnion(children)
 
     @staticmethod
-    def backward_map_index(objs: Tuple[CombinatorialObjectType, ...],) -> int:
+    def backward_map_index(objs: Tuple[Optional[CombinatorialObjectType], ...]) -> int:
         """
         Return the index of the comb_class that the sub_object returned.
         """
         for idx, obj in enumerate(objs):
-            if isinstance(obj, CombinatorialObject):
+            if obj is not None:
                 return idx
         raise ObjectMappingError(
             "For a disjoint union strategy, an object O is mapped to the tuple"
@@ -385,7 +385,7 @@ class DisjointUnionStrategy(Strategy[CombinatorialClassType, CombinatorialObject
     def backward_map(
         self,
         comb_class: CombinatorialClassType,
-        objs: Tuple[CombinatorialObjectType, ...],
+        objs: Tuple[Optional[CombinatorialObjectType], ...],
         children: Optional[Tuple[CombinatorialClassType, ...]] = None,
     ) -> CombinatorialObjectType:
         """
@@ -394,7 +394,8 @@ class DisjointUnionStrategy(Strategy[CombinatorialClassType, CombinatorialObject
         """
         if children is None:
             children = self.decomposition_function(comb_class)
-        return objs[DisjointUnionStrategy.backward_map_index(objs)]
+        idx = DisjointUnionStrategy.backward_map_index(objs)
+        return cast(CombinatorialObjectType, objs[idx])
 
 
 class SymmetryStrategy(

--- a/example.py
+++ b/example.py
@@ -263,7 +263,7 @@ class RemoveFrontOfPrefix(CartesianProductStrategy[AvoidingWithPrefix, Word]):
     def backward_map(
         self,
         avoiding_with_prefix: AvoidingWithPrefix,
-        words: Tuple[CombinatorialObject, ...],
+        words: Tuple[Optional[CombinatorialObject], ...],
         children: Optional[Tuple[AvoidingWithPrefix, ...]] = None,
     ) -> Word:
         """


### PR DESCRIPTION
Implemented the backward map for when a batch strategy became an equivalence rule.

This highlighted that the type for the image of the bijection was incorrect. I should be  `Tuple[Optional[CombinatorialObjectType], ...]`, so this has been added to. 

Finally, sneaking in is a tiny optimisation in CombinatorialSpecification, to prevent computing is-empty as regularly.