### PR TITLE
Manually increase recursion depth for counting and sampling

### DIFF
--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -24,7 +24,7 @@ from .strategies import (
     VerificationStrategy,
 )
 from .strategies.rule import AbstractRule
-from .utils import maple_equations, taylor_expand
+from .utils import RecursionLimit, maple_equations, taylor_expand
 
 __all__ = ("CombinatorialSpecification",)
 
@@ -177,7 +177,9 @@ class CombinatorialSpecification(
         Return the number of objects with the given parameters.
         Note, 'n' is reserved for the size of the object.
         """
-        return self.root_rule.count_objects_of_size(n, **parameters)
+        limit = n * self.number_of_rules()
+        with RecursionLimit(limit):
+            return self.root_rule.count_objects_of_size(n, **parameters)
 
     def generate_objects_of_size(
         self, n: int, **parameters
@@ -196,7 +198,9 @@ class CombinatorialSpecification(
         Return a uniformly random object of the given size. This is done using
         the "recursive" method.
         """
-        return self.root_rule.random_sample_object_of_size(n, **parameters)
+        limit = n * self.number_of_rules()
+        with RecursionLimit(limit):
+            return self.root_rule.random_sample_object_of_size(n, **parameters)
 
     def number_of_rules(self) -> int:
         return len(self.rules_dict)

--- a/comb_spec_searcher/utils.py
+++ b/comb_spec_searcher/utils.py
@@ -1,4 +1,5 @@
 """Some useful miscellaneous functions used througout the package."""
+import sys
 import time
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
@@ -48,6 +49,25 @@ class cssiteratortimer:
                 start = time.time()
 
         return cast(Func, inner)
+
+
+class RecursionLimit:
+    """
+    A context manager to momentarily increase the recursion limit.
+    """
+
+    def __init__(self, limit: int):
+        self.curr_limit = sys.getrecursionlimit()
+        if self.curr_limit < limit:
+            self.limit = limit
+        else:
+            self.limit = self.curr_limit
+
+    def __enter__(self) -> None:
+        sys.setrecursionlimit(self.limit)
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        sys.setrecursionlimit(self.curr_limit)
 
 
 def check_poly(min_poly, initial, root_initial=None, root_func=None):

--- a/tests/test_proof_tree.py
+++ b/tests/test_proof_tree.py
@@ -66,3 +66,14 @@ def test_generate_objects_of_length(specification):
     assert len(list(specification.generate_objects_of_size(4))) == 15
     assert Word("babb") not in specification.generate_objects_of_size(4)
     assert Word("aaaa") in specification.generate_objects_of_size(4)
+
+
+def test_count_object_of_length_big_value(specification):
+    specification.count_objects_of_size(1000)
+
+
+def test_random_sample(specification):
+    """
+    Just test that it works and don't hit the maximum recursion depth.
+    """
+    assert len(specification.random_sample_object_of_size(1000)) == 1000


### PR DESCRIPTION
Added and RecursionLimit context manager and use it for counting and
sampling in specification.

This fix the problem of hitting maximum recursion depth when sampling of counting from specification.