### PR TITLE
WIP: Add pympler stats to cpython

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,5 +10,5 @@ ignore_errors = True
 [mypy-permuta.*]
 ignore_missing_imports = True
 
-[mypy-sympy.*,pytest.*,logzero.*,psutil.*]
+[mypy-sympy.*,pytest.*,logzero.*,psutil.*,pympler.*,setuptools.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,10 @@ setup(
         "Topic :: Education",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
-    install_requires=["logzero==1.5.0", "sympy==1.5.1", "psutil==5.7.0"],
+    install_requires=[
+        "logzero==1.5.0",
+        "sympy==1.5.1",
+        "psutil==5.7.0",
+        "pympler==0.8",
+    ],
 )


### PR DESCRIPTION
Fails a pylint test for too many instance variables, but this is just to give you all an idea of what it would look like to see if we want it.

Computing memory use is SLOW, so it's set up to never use more than 1% of run time. A status update that computes mem usage looks like this:
```
    Memory Status:
    	Total Memory OS has Allocated: 121.9 MiB
    	CSS Size: 26.2 MiB
    	ClassDB Size: 7.2 MiB
    	ClassQueue Size: 1.9 MiB
    	RuleDB Size: 17.5 MiB
    		[mem analysis took 2.57 seconds]
```
and one that doesn't looks like this:
```
    Memory Status:
    	Total Memory OS has Allocated: 139.5 MiB
    		[last mem analysis took 2.57 seconds
    		 next in 223.93 seconds]
```