### PR TITLE
Sancheck specification

### DIFF
--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -296,6 +296,17 @@ class CombinatorialSpecification(
     def number_of_rules(self) -> int:
         return len(self.rules_dict)
 
+    def sanity_check(self, length: int = 5) -> bool:
+        """
+        Sanity check the specification to the given length.
+
+        Raise an SanityCheckFailure error if it fails.
+        """
+        return all(
+            all(rule.sanity_check(n) for rule in self.rules_dict.values())
+            for n in range(length + 1)
+        )
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CombinatorialSpecification):
             return NotImplemented

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -170,7 +170,11 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
         """Return a random objects of the give size."""
 
     def sanity_check(self, n: int, **parameters: int) -> bool:
-        """Sanity check that this is a valid rule."""
+        """
+        Sanity check that this is a valid rule.
+
+        Raise a SanityCheckFailure error if the sanity_check fails.
+        """
         if isinstance(self, VerificationRule):
             # TODO: test more thoroughly
             return True
@@ -192,21 +196,15 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
         )
         rule_count = self.count_objects_of_size(n, **parameters)
         self.subrecs = temprec
-        try:
-            assert actual_count == rule_count
-        except AssertionError:
+        params_str = ", ".join([f"n = {n}"] + [f"{p} = {v}" for p, v in parameters])
+        if actual_count != rule_count:
             raise SanityCheckFailure(
-                "The following rule failed sanity check:\n{}\nFailed with "
-                "parameters:\n{}\nThe actual count is {}. "
-                "The rule count is {}.".format(
-                    self,
-                    ", ".join(
-                        ["n = {}".format(n)]
-                        + ["{} = {}".format(p, v) for p, v in parameters]
-                    ),
-                    actual_count,
-                    rule_count,
-                )
+                f"The following rule failed sanity check:\n"
+                f"{self}\n"
+                f"Failed with parameters:\n"
+                f"{params_str}\n"
+                f"The actual count is {actual_count}.\n"
+                f"The rule count is {rule_count}.",
             )
 
         actual_objects = set(
@@ -218,19 +216,15 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
         )
         rule_objects = set(list(self.generate_objects_of_size(n, **parameters)))
         self.subgenerators = tempgen
-        try:
-            assert actual_objects == rule_objects
-        except AssertionError:
+        if actual_objects != rule_objects:
             raise SanityCheckFailure(
-                "The following rule failed sanity check:\n{}\nFailed with "
-                "parameters:\n{}\nThe rule generated the wrong objects.".format(
-                    self,
-                    ", ".join(
-                        ["n = {}".format(n)]
-                        + ["{} = {}".format(p, v) for p, v in parameters]
-                    ),
-                )
+                f"The following rule failed sanity check:\n"
+                f"{self}\n"
+                f"Failed with parameters:\n"
+                f"{params_str}\n"
+                f"The rule generated the wrong objects."
             )
+        return True
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AbstractRule):

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -84,3 +84,7 @@ def test_forget_ruledb():
     start_class = AvoidingWithPrefix("", ["ababa", "babb"], alphabet)
     searcher = CombinatorialSpecificationSearcher(start_class, pack, ruledb="forget")
     return searcher.auto_search()
+
+
+def test_sancheck(specification):
+    assert specification.sanity_check(6)


### PR DESCRIPTION
I fixed a bug with sanity checking the rule and also added sanity checking for a specification. I don't know if it is the best way in general but at least it works for one variable.