### PR TITLE
Log the string representation of the spec when found

### DIFF
--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -488,7 +488,8 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             round(time.time() - start_time, 2)
         )
         found_string += self.status(elaborate=True)
-        found_string += json.dumps(specification.to_jsonable())
+        found_string += str(specification)
+        found_string += json.dumps(specification.to_jsonable(), separators=(",", ":"))
         logger.info(found_string, extra=self.logger_kwargs)
 
     def _log_status(self, start_time: float) -> None:


### PR DESCRIPTION
Also removed spaced from the spec json so the representation is more
compact.