### PR TITLE
We need to change level while populating stage

### DIFF
--- a/comb_spec_searcher/class_queue.py
+++ b/comb_spec_searcher/class_queue.py
@@ -168,6 +168,8 @@ class DefaultQueue(CSSQueue):
                 self._change_level()
             while not self.staging and self.curr_level:
                 self.staging.extend(self._iter_helper_curr())
+                if not self.curr_level:
+                    self._change_level()
         if not self.staging:
             raise StopIteration("No more classes to expand")
 


### PR DESCRIPTION
if iter_helper_curr empties curr but does not add to staging, then it was previously falsely reporting no more classes to expand.