### PR TITLE
make extra params {parent: child}

### DIFF
--- a/comb_spec_searcher/strategies/strategy.py
+++ b/comb_spec_searcher/strategies/strategy.py
@@ -313,8 +313,8 @@ class Strategy(AbstractStrategy[CombinatorialClassType, CombinatorialObjectType]
         children: Optional[Tuple[CombinatorialClassType, ...]] = None,
     ) -> Tuple[Dict[str, str], ...]:
         """
-        This should be a tuple of dictionaries where the child parameters point
-        to the corresponding parent parameter. Any parent parameter not
+        This should be a tuple of dictionaries where the parent parameters point
+        to the corresponding child parameter. Any parent parameter not
         corresponding to a child parameter must have no objects that are on
         that child.
         """


### PR DESCRIPTION
The extra parameters are flipped to point from the parent to the child parameters. 

This is needed as sometimes the two different parent variables can point to the same child variable, for example, if a cell becomes empty.

Note: the Tilings test fails due to it needing its own bug fix!