### PR TITLE
Limiting the number of applications of strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - when subbing parameters use simultaneous flag
 
+### Changed
+- When the searcher finds a specification, it will now spends 1% of the time
+  spent searching trying to find a small specification instead of just returning
+  a random one.
+
 ## [1.1.0] - 2020-06-18
 ### Added
 - When expanding a class with a strategy, you can now create rules where the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - an option on `auto_search` to not expand verified classes
+- a `LimitedStrategyRuleDB` to find specifications with no more than a given number of
+  strategies of certain types
 
 ### Fixed
 - when subbing parameters use simultaneous flag
@@ -89,5 +91,3 @@ variables.
 ## [0.1.0] - 2019-04-15
 ### Added
 - This changelog file.
-
-

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -31,7 +31,8 @@ from .exception import (
     SpecificationNotFound,
     StrategyDoesNotApply,
 )
-from .rule_db import RuleDB, RuleDBBase, RuleDBForgetStrategy
+from .rule_db import RuleDB, RuleDBForgetStrategy
+from .rule_db.base import RuleDBBase
 from .specification import CombinatorialSpecification
 from .strategies import (
     AbstractStrategy,

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -73,7 +73,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
         start_class: CombinatorialClassType,
         strategy_pack: StrategyPack,
         ruledb: Optional[Union[str, RuleDB]] = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Initialise CombinatorialSpecificationSearcher.
@@ -610,6 +610,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             specification = self.get_specification(
                 smallest=kwargs.get("smallest", False),
                 expand_verified=kwargs.get("expand_verified", True),
+                minimization_time_limit=0.01 * (time.time() - spec_search_start),
             )
             if specification is not None:
                 self._log_spec_found(specification, auto_search_start)
@@ -633,10 +634,15 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
 
     @cssmethodtimer("get specification")
     def get_specification(
-        self, smallest: bool = False, expand_verified: bool = True
+        self,
+        minimization_time_limit: float = 10,
+        smallest: bool = False,
+        expand_verified: bool = True,
     ) -> Optional[CombinatorialSpecification]:
         """
         Return a CombinatorialSpecification if the universe contains one.
+
+        The minimization_time_limit only applies when smallest is false.
 
         The function will raise a SpecificationNotFound if no such
         CombinatorialSpecification exists in the universe.
@@ -650,7 +656,9 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
                 )
             else:
                 rules, eqv_paths = self.ruledb.get_specification_rules(
-                    self.start_label, iterative=self.iterative
+                    self.start_label,
+                    minimization_time_limit=minimization_time_limit,
+                    iterative=self.iterative,
                 )
         except SpecificationNotFound:
             return None

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -102,7 +102,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             self.ruledb: RuleDBBase = RuleDB()
         elif ruledb == "forget":
             self.ruledb = RuleDBForgetStrategy(self.classdb, self.strategy_pack)
-        elif isinstance(ruledb, RuleDB):
+        elif isinstance(ruledb, RuleDBBase):
             self.ruledb = ruledb
         else:
             raise ValueError(

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -5,7 +5,18 @@ import platform
 import time
 import warnings
 from collections import defaultdict
-from typing import Any, Dict, Generic, Iterator, Optional, Sequence, Set, Tuple, cast
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterator,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import logzero
 from logzero import logger
@@ -57,7 +68,11 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
     """
 
     def __init__(
-        self, start_class: CombinatorialClassType, strategy_pack: StrategyPack, **kwargs
+        self,
+        start_class: CombinatorialClassType,
+        strategy_pack: StrategyPack,
+        ruledb: Optional[Union[str, RuleDB]] = None,
+        **kwargs
     ):
         """
         Initialise CombinatorialSpecificationSearcher.
@@ -83,12 +98,16 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
         self.classdb = ClassDB[CombinatorialClassType](type(start_class))
         self.classqueue = DefaultQueue(strategy_pack)
 
-        if kwargs.get("ruledb") is None:
+        if ruledb is None:
             self.ruledb: RuleDBBase = RuleDB()
-        elif kwargs.get("ruledb") == "forget":
+        elif ruledb == "forget":
             self.ruledb = RuleDBForgetStrategy(self.classdb, self.strategy_pack)
+        elif isinstance(ruledb, RuleDB):
+            self.ruledb = ruledb
         else:
-            raise ValueError("ruledb argument should be None or 'forget'")
+            raise ValueError(
+                "ruledb argument should be None or 'forget' or a RuleDB object"
+            )
 
         # initialise the run with start_class
         self.start_label = self.classdb.get_label(start_class)

--- a/comb_spec_searcher/limited_strategy_db.py
+++ b/comb_spec_searcher/limited_strategy_db.py
@@ -1,5 +1,6 @@
 """
-    Do a docstring
+    An alternative ruledb that permits restricting the number of applications of a given
+    set of strategies to a given limit.
 """
 from copy import deepcopy
 from itertools import combinations

--- a/comb_spec_searcher/limited_strategy_db.py
+++ b/comb_spec_searcher/limited_strategy_db.py
@@ -118,6 +118,9 @@ class LimitedStrategyRuleDB(RuleDB):
         raise SpecificationNotFound("No specification for label {}".format(label))
 
     def smallish_random_proof_tree(self, rules_dict: RulesDict, root: int) -> Node:
+        """Searches a rule_dict known to contain at least one specification for a
+        small specification. Spends self.minimization_time_limit seconds searching."""
+
         def tree_size(tree):
             return len(list(tree.nodes()))
 

--- a/comb_spec_searcher/limited_strategy_db.py
+++ b/comb_spec_searcher/limited_strategy_db.py
@@ -1,0 +1,135 @@
+"""
+    Do a docstring
+"""
+from copy import deepcopy
+from itertools import combinations
+from time import time
+from typing import Dict, Set, Tuple, Type
+
+from logzero import logger
+
+from comb_spec_searcher.rule_db import RuleDB
+from comb_spec_searcher.strategies import AbstractStrategy
+
+from .exception import SpecificationNotFound
+from .tree_searcher import (
+    Node,
+    iterative_proof_tree_finder,
+    iterative_prune,
+    prune,
+    random_proof_tree,
+)
+
+LabelRule = Tuple[int, Tuple[int, ...]]
+RulesDict = Dict[int, Set[Tuple[int, ...]]]
+
+
+class LimitedStrategyRuleDB(RuleDB):
+    def __init__(
+        self,
+        strategies_to_limit: Set[Type[AbstractStrategy]],
+        limit: int,
+        mark_verified: bool,
+        minimization_time_limit: int,
+    ) -> None:
+        self.strategies_to_limit = strategies_to_limit
+        self.limit = limit
+        self.mark_verified = mark_verified
+        self.minimization_time_limit = minimization_time_limit
+        super().__init__()
+
+    def get_eqv_rules_using_strategies(self) -> Set[LabelRule]:
+        """
+        returns a set of rules, up to equivalence, that come from
+        <self.strategies_to_limit>
+        """
+        eqv_rules_using_strategies: Set[LabelRule] = set()
+        for label_rule in self:
+            rule_strat = self.rule_to_strategy[label_rule]
+            start, ends = label_rule
+            if any(isinstance(rule_strat, strat) for strat in self.strategies_to_limit):
+                temp_start = self.equivdb[start]
+                temp_ends = tuple(sorted(map(self.equivdb.__getitem__, ends)))
+                eqv_rules_using_strategies.add((temp_start, temp_ends))
+        return eqv_rules_using_strategies
+
+    def find_specification(self, label: int, iterative: bool = False) -> Node:
+        """Search for a specification based on current data found."""
+        rules_dict = self.rules_up_to_equivalence()
+        # Prune all unverified labels (recursively)
+        # Afterward, only verified labels remain in rules_dict. In particular, there
+        # is a specification if <label> is in the rules_dict
+        if iterative:
+            rules_dict = iterative_prune(rules_dict, root=label)
+        else:
+            prune(rules_dict)  # this function removes rules not in a specification.
+
+        if self.mark_verified:
+            for ver_label in rules_dict.keys():
+                self.set_verified(ver_label)
+
+        rules_to_isolate = self.get_eqv_rules_using_strategies()
+        logger.info("Found %s rules to isolate.", len(rules_to_isolate))
+
+        if len(rules_to_isolate) < self.limit:
+            rule_combos = [tuple(rules_to_isolate)]
+        else:
+            rule_combos = list(combinations(rules_to_isolate, self.limit))
+        num_combos = len(rule_combos)
+        logger.info("%s combinations to check", num_combos)
+        for i, combo in enumerate(rule_combos):
+            logger.info("[ %s / %s ]", i + 1, num_combos)
+            temp_rules_dict = deepcopy(rules_dict)
+            for lhs, rhs in rules_to_isolate:
+                if (lhs, rhs) in combo:
+                    continue
+                try:
+                    temp_rules_dict[lhs].remove(rhs)
+                except KeyError:
+                    pass
+                if len(temp_rules_dict[lhs]) == 0:
+                    del temp_rules_dict[lhs]
+            prune(temp_rules_dict)
+
+            if self.equivdb[label] in temp_rules_dict:
+                for l in temp_rules_dict.keys():
+                    self.set_verified(l)
+                if iterative:
+                    specification = iterative_proof_tree_finder(
+                        temp_rules_dict, root=self.equivdb[label]
+                    )
+                else:
+                    specification = self.smallish_random_proof_tree(
+                        temp_rules_dict, self.equivdb[label],
+                    )
+                return specification
+
+        raise SpecificationNotFound("No specification for label {}".format(label))
+
+    def smallish_random_proof_tree(self, rules_dict: RulesDict, root: int) -> Node:
+        def tree_size(tree):
+            return len(list(tree.nodes()))
+
+        start_time = time()
+        smallest_so_far = random_proof_tree(rules_dict, root=root)
+        smallest_size = tree_size(smallest_so_far)
+
+        logger.info("Found tree with size %s.", smallest_size)
+        logger.info(
+            "Looking for a smaller one for %s seconds", self.minimization_time_limit
+        )
+
+        num_searches = 1
+        while time() - start_time < self.minimization_time_limit:
+            num_searches += 1
+            next_tree = random_proof_tree(rules_dict, root=root)
+            next_tree_size = tree_size(next_tree)
+            if next_tree_size < smallest_size:
+                smallest_so_far = next_tree
+                smallest_size = next_tree_size
+
+        logger.info(
+            "After %s searches, the smallest has size %s.", num_searches, smallest_size
+        )
+
+        return smallest_so_far

--- a/comb_spec_searcher/limited_strategy_db.py
+++ b/comb_spec_searcher/limited_strategy_db.py
@@ -102,8 +102,8 @@ class LimitedStrategyRuleDB(RuleDB):
             prune(temp_rules_dict)
 
             if self.equivdb[label] in temp_rules_dict:
-                for l in temp_rules_dict.keys():
-                    self.set_verified(l)
+                for label_in_spec in temp_rules_dict.keys():
+                    self.set_verified(label_in_spec)
                 if iterative:
                     specification = iterative_proof_tree_finder(
                         temp_rules_dict, root=self.equivdb[label]

--- a/comb_spec_searcher/limited_strategy_db.py
+++ b/comb_spec_searcher/limited_strategy_db.py
@@ -55,7 +55,7 @@ class LimitedStrategyRuleDB(RuleDB):
         for label_rule in self:
             rule_strat = self.rule_to_strategy[label_rule]
             start, ends = label_rule
-            if any(isinstance(rule_strat, strat) for strat in self.strategies_to_limit):
+            if isinstance(rule_strat, tuple(self.strategies_to_limit)):
                 temp_start = self.equivdb[start]
                 temp_ends = tuple(sorted(map(self.equivdb.__getitem__, ends)))
                 eqv_rules_using_strategies.add((temp_start, temp_ends))

--- a/comb_spec_searcher/rule_db/__init__.py
+++ b/comb_spec_searcher/rule_db/__init__.py
@@ -1,0 +1,5 @@
+from .base import RuleDB
+from .forget import RuleDBForgetStrategy
+from .limited_strategy import LimitedStrategyRuleDB
+
+__all__ = ["RuleDB", "RuleDBForgetStrategy", "LimitedStrategyRuleDB"]

--- a/comb_spec_searcher/rule_db/base.py
+++ b/comb_spec_searcher/rule_db/base.py
@@ -18,6 +18,7 @@ from comb_spec_searcher.tree_searcher import (
     proof_tree_generator_dfs,
     prune,
     random_proof_tree,
+    smallish_random_proof_tree,
 )
 
 __all__ = ["RuleDBBase", "RuleDB"]
@@ -138,7 +139,9 @@ class RuleDBBase(abc.ABC):
                 return start, ends
         return None
 
-    def find_specification(self, label: int, iterative: bool = False) -> Node:
+    def find_specification(
+        self, label: int, minimization_time_limit: float, iterative: bool = False
+    ) -> Node:
         """Search for a specification based on current data found."""
         rules_dict = self.rules_up_to_equivalence()
         # Prune all unverified labels (recursively)
@@ -158,20 +161,26 @@ class RuleDBBase(abc.ABC):
                     rules_dict, root=self.equivdb[label]
                 )
             else:
-                specification = random_proof_tree(rules_dict, root=self.equivdb[label])
+                specification = smallish_random_proof_tree(
+                    rules_dict, self.equivdb[label], minimization_time_limit
+                )
         else:
             raise SpecificationNotFound("No specification for label {}".format(label))
         return specification
 
     def get_specification_rules(
-        self, label: int, iterative: bool = False
+        self, label: int, minimization_time_limit: float, iterative: bool = False
     ) -> Specification:
         """
         Return a list of pairs (label, rule) which form a specification.
         The specification returned is random, so two calls to the function
         may result in a a different output.
         """
-        proof_tree_node = self.find_specification(label=label, iterative=iterative)
+        proof_tree_node = self.find_specification(
+            label=label,
+            iterative=iterative,
+            minimization_time_limit=minimization_time_limit,
+        )
         return self._get_specification_rules(label, proof_tree_node)
 
     def _get_specification_rules(

--- a/comb_spec_searcher/rule_db/base.py
+++ b/comb_spec_searcher/rule_db/base.py
@@ -3,28 +3,15 @@ A database for rules.
 """
 import abc
 from collections import defaultdict
-from typing import (
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Dict, Iterable, Iterator, List, MutableMapping, Optional, Set, Tuple
 
 from logzero import logger
 
-from .class_db import ClassDB
-from .equiv_db import EquivalenceDB
-from .exception import SpecificationNotFound, StrategyDoesNotApply
-from .strategies import Rule, StrategyPack, VerificationRule
-from .strategies.rule import AbstractRule
-from .strategies.strategy import AbstractStrategy, StrategyFactory
-from .tree_searcher import (
+from comb_spec_searcher.equiv_db import EquivalenceDB
+from comb_spec_searcher.exception import SpecificationNotFound
+from comb_spec_searcher.strategies import AbstractStrategy, Rule, VerificationRule
+from comb_spec_searcher.strategies.rule import AbstractRule
+from comb_spec_searcher.tree_searcher import (
     Node,
     iterative_proof_tree_finder,
     iterative_prune,
@@ -32,6 +19,8 @@ from .tree_searcher import (
     prune,
     random_proof_tree,
 )
+
+__all__ = ["RuleDBBase", "RuleDB"]
 
 Specification = Tuple[List[Tuple[int, AbstractStrategy]], List[List[int]]]
 RuleKey = Tuple[int, Tuple[int, ...]]
@@ -287,83 +276,3 @@ class RuleDB(RuleDBBase):
     @property
     def rule_to_strategy(self) -> Dict[Tuple[int, Tuple[int, ...]], AbstractStrategy]:
         return self._rule_to_strategy
-
-
-class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
-    """
-    A mapping from rules to strategies that recompute the strategy every time it's
-    needed instead of storing it in order to save memory.
-
-    Also in order to save memory we store flat version of the rules, i.e. for a rule
-    (a, (b, c,...)) we store (a, b, c,...)
-    """
-
-    def __init__(self, classdb: ClassDB, strat_pack: StrategyPack) -> None:
-        self.classdb = classdb
-        self.pack = strat_pack
-        self.rules: Set[Tuple[int, ...]] = set()
-
-    @staticmethod
-    def _flatten(tuple_: RuleKey) -> Tuple[int, ...]:
-        return (tuple_[0],) + tuple_[1]
-
-    @staticmethod
-    def _unflatten(tuple_: Tuple[int, ...]) -> RuleKey:
-        return (tuple_[0], tuple_[1:])
-
-    def __getitem__(self, key: RuleKey) -> AbstractStrategy:
-        if self._flatten(key) not in self.rules:
-            raise KeyError(key)
-        parent = self.classdb.get_class(key[0])
-        for strat in self.pack:
-            if isinstance(strat, StrategyFactory):
-                strats_or_rules: Iterable[Union[Rule, AbstractStrategy]] = strat(parent)
-            else:
-                strats_or_rules = [strat]
-            rules: Iterator[AbstractRule] = (
-                x(parent) if isinstance(x, AbstractStrategy) else x
-                for x in strats_or_rules
-            )
-            for rule in rules:
-                try:
-                    nonempty_children = tuple(
-                        c for c in rule.children if not self.classdb.is_empty(c)
-                    )
-                    end_labels = tuple(
-                        sorted(map(self.classdb.get_label, nonempty_children))
-                    )
-                    if end_labels == key[1]:
-                        return rule.strategy
-                except StrategyDoesNotApply:
-                    pass
-        err_message = (
-            f"Could not recompute the strategy for the rule {key} with "
-            " any of the strategies"
-        )
-        raise RuntimeError(err_message)
-
-    def __setitem__(self, key: RuleKey, value: AbstractStrategy) -> None:
-        self.rules.add(self._flatten(key))
-
-    def __delitem__(self, key: RuleKey) -> None:
-        self.rules.remove(self._flatten(key))
-
-    def __iter__(self) -> Iterator[RuleKey]:
-        for rule in self.rules:
-            yield self._unflatten(rule)
-
-    def __len__(self) -> int:
-        return len(self.rules)
-
-    def __contains__(self, key: object) -> bool:
-        return self._flatten(cast(RuleKey, key)) in self.rules
-
-
-class RuleDBForgetStrategy(RuleDBBase):
-    def __init__(self, classdb: ClassDB, strat_pack: StrategyPack) -> None:
-        super().__init__()
-        self.rules = RecomputingDict(classdb, strat_pack)
-
-    @property
-    def rule_to_strategy(self):
-        return self.rules

--- a/comb_spec_searcher/rule_db/forget.py
+++ b/comb_spec_searcher/rule_db/forget.py
@@ -1,0 +1,98 @@
+"""
+A database for rules.
+"""
+from typing import Iterable, Iterator, List, MutableMapping, Set, Tuple, Union, cast
+
+from comb_spec_searcher.class_db import ClassDB
+from comb_spec_searcher.exception import StrategyDoesNotApply
+from comb_spec_searcher.strategies import Rule
+from comb_spec_searcher.strategies.rule import AbstractRule
+from comb_spec_searcher.strategies.strategy import AbstractStrategy, StrategyFactory
+from comb_spec_searcher.strategies.strategy_pack import StrategyPack
+
+from .base import RuleDBBase
+
+__all__ = ["RuleDBForgetStrategy"]
+
+Specification = Tuple[List[Tuple[int, AbstractStrategy]], List[List[int]]]
+RuleKey = Tuple[int, Tuple[int, ...]]
+
+
+class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
+    """
+    A mapping from rules to strategies that recompute the strategy every time it's
+    needed instead of storing it in order to save memory.
+
+    Also in order to save memory we store flat version of the rules, i.e. for a rule
+    (a, (b, c,...)) we store (a, b, c,...)
+    """
+
+    def __init__(self, classdb: ClassDB, strat_pack: StrategyPack) -> None:
+        self.classdb = classdb
+        self.pack = strat_pack
+        self.rules: Set[Tuple[int, ...]] = set()
+
+    @staticmethod
+    def _flatten(tuple_: RuleKey) -> Tuple[int, ...]:
+        return (tuple_[0],) + tuple_[1]
+
+    @staticmethod
+    def _unflatten(tuple_: Tuple[int, ...]) -> RuleKey:
+        return (tuple_[0], tuple_[1:])
+
+    def __getitem__(self, key: RuleKey) -> AbstractStrategy:
+        if self._flatten(key) not in self.rules:
+            raise KeyError(key)
+        parent = self.classdb.get_class(key[0])
+        for strat in self.pack:
+            if isinstance(strat, StrategyFactory):
+                strats_or_rules: Iterable[Union[Rule, AbstractStrategy]] = strat(parent)
+            else:
+                strats_or_rules = [strat]
+            rules: Iterator[AbstractRule] = (
+                x(parent) if isinstance(x, AbstractStrategy) else x
+                for x in strats_or_rules
+            )
+            for rule in rules:
+                try:
+                    nonempty_children = tuple(
+                        c for c in rule.children if not self.classdb.is_empty(c)
+                    )
+                    end_labels = tuple(
+                        sorted(map(self.classdb.get_label, nonempty_children))
+                    )
+                    if end_labels == key[1]:
+                        return rule.strategy
+                except StrategyDoesNotApply:
+                    pass
+        err_message = (
+            f"Could not recompute the strategy for the rule {key} with "
+            " any of the strategies"
+        )
+        raise RuntimeError(err_message)
+
+    def __setitem__(self, key: RuleKey, value: AbstractStrategy) -> None:
+        self.rules.add(self._flatten(key))
+
+    def __delitem__(self, key: RuleKey) -> None:
+        self.rules.remove(self._flatten(key))
+
+    def __iter__(self) -> Iterator[RuleKey]:
+        for rule in self.rules:
+            yield self._unflatten(rule)
+
+    def __len__(self) -> int:
+        return len(self.rules)
+
+    def __contains__(self, key: object) -> bool:
+        return self._flatten(cast(RuleKey, key)) in self.rules
+
+
+class RuleDBForgetStrategy(RuleDBBase):
+    def __init__(self, classdb: ClassDB, strat_pack: StrategyPack) -> None:
+        super().__init__()
+        self.rules = RecomputingDict(classdb, strat_pack)
+
+    @property
+    def rule_to_strategy(self):
+        return self.rules

--- a/comb_spec_searcher/rule_db/limited_strategy.py
+++ b/comb_spec_searcher/rule_db/limited_strategy.py
@@ -9,11 +9,10 @@ from typing import Dict, Iterable, Set, Tuple, Type
 
 from logzero import logger
 
+from comb_spec_searcher.exception import SpecificationNotFound
 from comb_spec_searcher.rule_db import RuleDB
 from comb_spec_searcher.strategies import AbstractStrategy
-
-from .exception import SpecificationNotFound
-from .tree_searcher import (
+from comb_spec_searcher.tree_searcher import (
     Node,
     iterative_proof_tree_finder,
     iterative_prune,

--- a/comb_spec_searcher/tree_searcher.py
+++ b/comb_spec_searcher/tree_searcher.py
@@ -1,6 +1,7 @@
 """
 Finds and returns a combinatorial specification, that we call a proof tree.
 """
+import time
 from collections import defaultdict, deque
 from copy import deepcopy
 from itertools import chain, product
@@ -145,6 +146,25 @@ def random_proof_tree(rules_dict: RulesDict, root: int) -> Node:
             v.children = children
         seen.add(v.label)
     return root_node
+
+
+def smallish_random_proof_tree(
+    rules_dict: RulesDict, root: int, minimization_time_limit: float
+) -> Node:
+    """
+    Searches a rule_dict known to contain at least one specification for a
+    small specification. Spends minimization_time_limit seconds searching.
+    """
+    start_time = time.time()
+    smallest_so_far = random_proof_tree(rules_dict, root=root)
+    smallest_size = len(smallest_so_far)
+    while time.time() - start_time < minimization_time_limit:
+        next_tree = random_proof_tree(rules_dict, root=root)
+        next_tree_size = len(next_tree)
+        if next_tree_size < smallest_size:
+            smallest_so_far = next_tree
+            smallest_size = next_tree_size
+    return smallest_so_far
 
 
 def proof_tree_generator_bfs(rules_dict: RulesDict, root: int) -> Iterator[Node]:


### PR DESCRIPTION
This PR creates a new ruledb that can be used to enforce a limit on the number of strategies of certain types that can appear in a specification.

It also has functionality to randomly sample specifications for a preset number of seconds after the first specification has been found in an attempt at partial minimization.

The calling sequence to use this ruledb looks as follows:
```python
ruledb = LimitedStrategyRuleDB(
		strategies_to_limit = set([FusionStrategy]),
		limit = 1,
		mark_verified = True,
		minimization_time_limit = 10
	)

css = TileScope(basis, pack, ruledb=ruledb)
```
