### PR TITLE
Fixes a minimization bug

### DIFF
--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -610,7 +610,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             specification = self.get_specification(
                 smallest=kwargs.get("smallest", False),
                 expand_verified=kwargs.get("expand_verified", True),
-                minimization_time_limit=0.01 * (time.time() - spec_search_start),
+                minimization_time_limit=0.01 * (time.time() - auto_search_start),
             )
             if specification is not None:
                 self._log_spec_found(specification, auto_search_start)


### PR DESCRIPTION
The minimization time for `smallish_random_proof_tree` was set to 1% of the specification search time, rather than the entire auto_search time.