### PR TITLE
Bug in forgetdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - when subbing parameters use simultaneous flag
+- Retrieving the rule in the forget db when the rules comes from applying a
+  strategy to a child.
 
 ### Changed
 - When the searcher finds a specification, it will now spends 1% of the time

--- a/comb_spec_searcher/rule_db/forget.py
+++ b/comb_spec_searcher/rule_db/forget.py
@@ -44,7 +44,7 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
     def __getitem__(self, key: RuleKey) -> AbstractStrategy:
         if self._flatten(key) not in self.rules:
             raise KeyError(key)
-        possible_comb_classes = tuple(map(self.classdb.get_class, (key[0],) + (key[1])))
+        possible_comb_classes = tuple(map(self.classdb.get_class, (key[0],) + key[1]))
         for comb_class, strat in product(possible_comb_classes, self.pack):
             if isinstance(strat, StrategyFactory):
                 strats_or_rules: Iterable[Union[Rule, AbstractStrategy]] = strat(

--- a/comb_spec_searcher/rule_db/forget.py
+++ b/comb_spec_searcher/rule_db/forget.py
@@ -44,8 +44,9 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
     def __getitem__(self, key: RuleKey) -> AbstractStrategy:
         if self._flatten(key) not in self.rules:
             raise KeyError(key)
-        possible_comb_classes = tuple(map(self.classdb.get_class, (key[0],) + key[1]))
-        for comb_class, strat in product(possible_comb_classes, self.pack):
+        possible_labels = (key[0],) + key[1]
+        for label, strat in product(possible_labels, self.pack):
+            comb_class = self.classdb.get_class(label)
             if isinstance(strat, StrategyFactory):
                 strats_or_rules: Iterable[Union[Rule, AbstractStrategy]] = strat(
                     comb_class


### PR DESCRIPTION
Now we can also retrieve the rule in the forget db when the rules comes from applying a
strategy to a child of the rule.