### PR TITLE
Reverse rule constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   strategy to a child.
 - When a parameter does not map to equivalent child we don't look for it on the
   child, preventing a `KeyError`.
+- the extra parameters dictionary is flipped when creating the constructor in a
+  reverse rule.
 
 ### Changed
 - When the searcher finds a specification, it will now spends 1% of the time

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -655,10 +655,19 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
         ), "reversing a rule only works for equivalence rules"
         super().__init__(rule.strategy, rule.children[0], (rule.comb_class,))
         self.original_rule = rule
+        self._constructor: Optional[Constructor] = None
 
     @property
     def constructor(self) -> Constructor:
-        return self.strategy.constructor(self.comb_class, self.children)
+        if self._constructor is None:
+            constructor = cast(DisjointUnion, self.original_rule.constructor)
+            flipped_extra_params = {
+                b: a for a, b in constructor.extra_parameters[0].items()
+            }
+            self._constructor = DisjointUnion(
+                self.comb_class, self.children, (flipped_extra_params,)
+            )
+        return self._constructor
 
     @property
     def formal_step(self) -> str:

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -655,10 +655,10 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
         ), "reversing a rule only works for equivalence rules"
         super().__init__(rule.strategy, rule.children[0], (rule.comb_class,))
         self.original_rule = rule
-        self._constructor: Optional[Constructor] = None
+        self._constructor: Optional[DisjointUnion] = None
 
     @property
-    def constructor(self) -> Constructor:
+    def constructor(self) -> DisjointUnion:
         if self._constructor is None:
             constructor = cast(DisjointUnion, self.original_rule.constructor)
             flipped_extra_params = {

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -661,6 +661,10 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
     def constructor(self) -> DisjointUnion:
         if self._constructor is None:
             constructor = cast(DisjointUnion, self.original_rule.constructor)
+            assert isinstance(constructor, DisjointUnion), (
+                "reverse rule coming from non disjoint union strategy - "
+                "you'll need to update the ReverseRule constructor!"
+            )
             flipped_extra_params = {
                 b: a for a, b in constructor.extra_parameters[0].items()
             }


### PR DESCRIPTION
### Fixed
- the extra parameters dictionary is flipped when creating the constructor in a
  reverse rule.

I have added the offending rule to a test bed on Tilings for when I have implemented sanity check of multiple variables.