### PR TITLE
sanity check multiple variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - a `LimitedStrategyRuleDB` to find specifications with no more than a given number of
   strategies of certain types
 - log information when expanding a verified combinatorial class.
+- sanity checking in multiple variables. In order to use this one must implement
+  the method `possible_parameters` on their `CombinatorialClass`. The sanity
+  checker only checks counts, not generation of objects.
 
 ### Fixed
 - when subbing parameters use simultaneous flag

--- a/comb_spec_searcher/combinatorial_class.py
+++ b/comb_spec_searcher/combinatorial_class.py
@@ -3,7 +3,7 @@ An abstract class for a CombinatorialClass.
 """
 import abc
 from importlib import import_module
-from typing import Any, Generic, Iterator, Tuple, Type, TypeVar
+from typing import Any, Dict, Generic, Iterator, Tuple, Type, TypeVar
 
 __all__ = ("CombinatorialClass", "CombinatorialObject")
 
@@ -88,6 +88,13 @@ class CombinatorialClass(Generic[CombinatorialObjectType], abc.ABC):
         class. It is assumed we are always aware of 'n' which counts size.
         """
         return tuple()
+
+    def possible_parameters(self, n: int) -> Iterator[Dict[str, int]]:
+        """
+        Return all the possible values the extra parameters could take for
+        the given value of n.
+        """
+        yield dict()
 
     def objects_of_size(
         self, n: int, **parameters: int

--- a/comb_spec_searcher/combinatorial_class.py
+++ b/comb_spec_searcher/combinatorial_class.py
@@ -94,6 +94,12 @@ class CombinatorialClass(Generic[CombinatorialObjectType], abc.ABC):
         Return all the possible values the extra parameters could take for
         the given value of n.
         """
+        if self.extra_parameters:
+            raise NotImplementedError(
+                "You need to implement the possible parameters on your "
+                "CombinatorialClass in order to use various methods, including "
+                "sanity checking."
+            )
         yield dict()
 
     def objects_of_size(

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -379,7 +379,11 @@ class CombinatorialSpecification(
         Raise an SanityCheckFailure error if it fails.
         """
         return all(
-            all(rule.sanity_check(n) for rule in self.rules_dict.values())
+            all(
+                rule.sanity_check(n, **parameters)
+                for rule in self.rules_dict.values()
+                for parameters in rule.comb_class.possible_parameters(n)
+            )
             for n in range(length + 1)
         )
 

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -180,8 +180,6 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
 
         Raise a SanityCheckFailure error if the sanity_check fails.
         """
-        if self.comb_class.extra_parameters:
-            raise NotImplementedError("sanity check only implemented in one variable")
 
         if isinstance(self, VerificationRule):
             # TODO: test more thoroughly
@@ -216,7 +214,13 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
                 f"The actual count is {actual_count}.\n"
                 f"The rule count is {rule_count}.",
             )
-
+        if any(
+            comb_class.extra_parameters
+            for comb_class in [self.comb_class, *self.children]
+        ):
+            # Can't sanity check generation of objects for classes with extra
+            # TODO test more thoroughly
+            return True
         actual_objects = set(
             list(brute_force_generation(self.comb_class, n, **parameters))
         )


### PR DESCRIPTION
### Added
- sanity checking in multiple variables. In order to use this one must implement
  the method `possible_parameters` on their `CombinatorialClass`. The sanity
  checker only checks counts, not generation of objects.