### PR TITLE
Ensure ruledb doesn't return non-equivalent rule when two labels are equivalent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - a `LimitedStrategyRuleDB` to find specifications with no more than a given number of
   strategies of certain types
 - log information when expanding a verified combinatorial class.
+- added `is_equivalence` method to `Rule`
 
 ### Fixed
 - when subbing parameters use simultaneous flag
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - the extra parameters dictionary is flipped when creating the constructor in a
   reverse rule.
 - fixed the `EquivalencePathRule.constructor` method
+- only save equivalence rules for rules a -> (b,) if a and b are equivalent.
 
 ### Changed
 - When the searcher finds a specification, it will now spends 1% of the time

--- a/comb_spec_searcher/rule_db/base.py
+++ b/comb_spec_searcher/rule_db/base.py
@@ -9,7 +9,7 @@ from logzero import logger
 
 from comb_spec_searcher.equiv_db import EquivalenceDB
 from comb_spec_searcher.exception import SpecificationNotFound
-from comb_spec_searcher.strategies import AbstractStrategy, Rule, VerificationRule
+from comb_spec_searcher.strategies import AbstractStrategy, VerificationRule
 from comb_spec_searcher.strategies.rule import AbstractRule
 from comb_spec_searcher.tree_searcher import (
     Node,
@@ -55,19 +55,10 @@ class RuleDBBase(abc.ABC):
         ends = tuple(sorted(ends))
         if isinstance(rule, VerificationRule):
             self.set_verified(start)
-        if (
-            isinstance(rule, Rule)
-            and len(ends) == 1
-            and rule.constructor.is_equivalence()
-        ):
+        is_equiv = rule.is_equivalence()
+        if is_equiv:
             self.set_equivalent(start, ends[0])
-        if len(ends) != 1 or (
-            isinstance(rule, Rule)
-            and (
-                rule.constructor.is_equivalence()
-                or not self.are_equivalent(start, ends[0])
-            )
-        ):
+        if len(ends) != 1 or is_equiv or not self.are_equivalent(start, ends[0]):
             self.rule_to_strategy[(start, ends)] = rule.strategy
 
     def is_verified(self, label: int) -> bool:

--- a/comb_spec_searcher/rule_db/base.py
+++ b/comb_spec_searcher/rule_db/base.py
@@ -61,7 +61,14 @@ class RuleDBBase(abc.ABC):
             and rule.constructor.is_equivalence()
         ):
             self.set_equivalent(start, ends[0])
-        self.rule_to_strategy[(start, ends)] = rule.strategy
+        if len(ends) != 1 or (
+            isinstance(rule, Rule)
+            and (
+                rule.constructor.is_equivalence()
+                or not self.are_equivalent(start, ends[0])
+            )
+        ):
+            self.rule_to_strategy[(start, ends)] = rule.strategy
 
     def is_verified(self, label: int) -> bool:
         """Return True if label has been verified."""

--- a/comb_spec_searcher/rule_db/base.py
+++ b/comb_spec_searcher/rule_db/base.py
@@ -59,6 +59,9 @@ class RuleDBBase(abc.ABC):
         if is_equiv:
             self.set_equivalent(start, ends[0])
         if len(ends) != 1 or is_equiv or not self.are_equivalent(start, ends[0]):
+            # to avoid overwriting an equivalence rule with a non-equivalence
+            # rule, we only save if an equivalence rule, or does not have the
+            # same start -> ends as some equivalence rule.
             self.rule_to_strategy[(start, ends)] = rule.strategy
 
     def is_verified(self, label: int) -> bool:

--- a/comb_spec_searcher/rule_db/forget.py
+++ b/comb_spec_searcher/rule_db/forget.py
@@ -67,6 +67,15 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
                         sorted(map(self.classdb.get_label, nonempty_children))
                     )
                     if (start_label, end_labels) == key:
+                        if (
+                            len(end_labels) == 1
+                            and self.are_equivalent(start_label, end_labels[0])
+                            and (
+                                isinstance(rule, Rule)
+                                and not rule.constructor.is_equivalence()
+                            )
+                        ):
+                            continue
                         return rule.strategy
                 except StrategyDoesNotApply:
                     pass

--- a/comb_spec_searcher/rule_db/forget.py
+++ b/comb_spec_searcher/rule_db/forget.py
@@ -5,6 +5,7 @@ from itertools import product
 from typing import Iterable, Iterator, List, MutableMapping, Set, Tuple, Union, cast
 
 from comb_spec_searcher.class_db import ClassDB
+from comb_spec_searcher.equiv_db import EquivalenceDB
 from comb_spec_searcher.exception import StrategyDoesNotApply
 from comb_spec_searcher.strategies import Rule
 from comb_spec_searcher.strategies.rule import AbstractRule
@@ -28,8 +29,11 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
     (a, (b, c,...)) we store (a, b, c,...)
     """
 
-    def __init__(self, classdb: ClassDB, strat_pack: StrategyPack) -> None:
+    def __init__(
+        self, classdb: ClassDB, strat_pack: StrategyPack, equivdb: EquivalenceDB
+    ) -> None:
         self.classdb = classdb
+        self.equivdb = equivdb
         self.pack = strat_pack
         self.rules: Set[Tuple[int, ...]] = set()
 
@@ -41,9 +45,18 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
     def _unflatten(tuple_: Tuple[int, ...]) -> RuleKey:
         return (tuple_[0], tuple_[1:])
 
+    def _is_equiv(self, key: RuleKey) -> bool:
+        """
+        Returns True if the key should be the key of an equivalence rule.
+        """
+        start = key[0]
+        ends = key[1]
+        return len(ends) == 1 and self.equivdb.equivalent(start, ends[0])
+
     def __getitem__(self, key: RuleKey) -> AbstractStrategy:
         if self._flatten(key) not in self.rules:
             raise KeyError(key)
+        expect_equiv = self._is_equiv(key)
         possible_labels = (key[0],) + key[1]
         for label, strat in product(possible_labels, self.pack):
             comb_class = self.classdb.get_class(label)
@@ -67,14 +80,7 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
                         sorted(map(self.classdb.get_label, nonempty_children))
                     )
                     if (start_label, end_labels) == key:
-                        if (
-                            len(end_labels) == 1
-                            and self.are_equivalent(start_label, end_labels[0])
-                            and (
-                                isinstance(rule, Rule)
-                                and not rule.constructor.is_equivalence()
-                            )
-                        ):
+                        if expect_equiv and not rule.is_equivalence():
                             continue
                         return rule.strategy
                 except StrategyDoesNotApply:
@@ -105,7 +111,7 @@ class RecomputingDict(MutableMapping[RuleKey, AbstractStrategy]):
 class RuleDBForgetStrategy(RuleDBBase):
     def __init__(self, classdb: ClassDB, strat_pack: StrategyPack) -> None:
         super().__init__()
-        self.rules = RecomputingDict(classdb, strat_pack)
+        self.rules = RecomputingDict(classdb, strat_pack, self.equivdb)
 
     @property
     def rule_to_strategy(self):

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -99,11 +99,8 @@ class CombinatorialSpecification(
                 continue
             rule = strategy(comb_class)
             non_empty_children = rule.non_empty_children()
-            if (
-                isinstance(rule, Rule)
-                and len(non_empty_children) == 1
-                and rule.constructor.is_equivalence()
-            ):
+            if rule.is_equivalence():
+                assert isinstance(rule, Rule)
                 equivalence_rules[(comb_class, non_empty_children[0])] = (
                     rule if len(rule.children) == 1 else rule.to_equivalence_rule()
                 )

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -137,6 +137,12 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
         """
         return self._strategy.formal_step()
 
+    @abc.abstractmethod
+    def is_equivalence(self) -> bool:
+        """
+        Returns True if the rule is an equivalence.
+        """
+
     def non_empty_children(self) -> Tuple[CombinatorialClassType, ...]:
         """
         Return the tuple of non-empty combinatorial classes that are found
@@ -320,6 +326,9 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
                 raise StrategyDoesNotApply("{} does not apply".format(self.strategy))
         return self._constructor
 
+    def is_equivalence(self):
+        return len(self.non_empty_children()) == 1 and self.constructor.is_equivalence()
+
     def backward_map(
         self, objs: Tuple[Optional[CombinatorialObjectType], ...]
     ) -> CombinatorialObjectType:
@@ -344,8 +353,8 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         created for equivalence rules.
         """
         assert (
-            self.constructor.is_equivalence()
-        ), "EquivalenceRule can only be created for equivalence rules"
+            self.is_equivalence()
+        ), f"EquivalenceRule can only be created for equivalence rules\n{self}"
         return EquivalenceRule(self)
 
     def to_reverse_rule(self) -> "ReverseRule":
@@ -354,7 +363,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         created for equivalence rules.
         """
         assert (
-            len(self.children) == 1 and self.constructor.is_equivalence()
+            self.is_equivalence()
         ), "reverse rule can only be created for equivalence rules"
         return ReverseRule(self)
 
@@ -473,9 +482,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
 class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
     def __init__(self, rule: Rule):
         non_empty_children = rule.non_empty_children()
-        assert (
-            len(non_empty_children) == 1 and rule.constructor.is_equivalence()
-        ), "not an equivalence rule: {}".format(str(rule))
+        assert rule.is_equivalence(), "not an equivalence rule: {}".format(str(rule))
         child = non_empty_children[0]
         super().__init__(rule.strategy, rule.comb_class, (child,))
         self.child_idx = rule.children.index(child)
@@ -500,6 +507,10 @@ class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
                 (original_constructor.extra_parameters[self.child_idx],),
             )
         return self._constructor
+
+    @staticmethod
+    def is_equivalence() -> bool:
+        return True
 
     @property
     def formal_step(self) -> str:
@@ -534,10 +545,7 @@ class EquivalencePathRule(Rule[CombinatorialClassType, CombinatorialObjectType])
     """
 
     def __init__(self, rules: Sequence[Rule]):
-        assert all(
-            len(rule.children) == 1 and rule.constructor.is_equivalence()
-            for rule in rules
-        )
+        assert all(rule.is_equivalence() for rule in rules)
         super().__init__(rules[0].strategy, rules[0].comb_class, rules[-1].children)
         self.rules = rules
         self._constructor: Optional[DisjointUnion] = None
@@ -563,6 +571,10 @@ class EquivalencePathRule(Rule[CombinatorialClassType, CombinatorialObjectType])
                 self.comb_class, self.children, (extra_parameters,)
             )
         return self._constructor
+
+    @staticmethod
+    def is_equivalence() -> bool:
+        return True
 
     @property
     def formal_step(self) -> str:
@@ -641,7 +653,7 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
 
     def __init__(self, rule: Rule):
         assert (
-            len(rule.children) == 1 and rule.constructor.is_equivalence
+            rule.is_equivalence()
         ), "reversing a rule only works for equivalence rules"
         super().__init__(rule.strategy, rule.children[0], (rule.comb_class,))
         self.original_rule = rule
@@ -662,6 +674,10 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
                 self.comb_class, self.children, (flipped_extra_params,)
             )
         return self._constructor
+
+    @staticmethod
+    def is_equivalence() -> bool:
+        return True
 
     @property
     def formal_step(self) -> str:
@@ -701,6 +717,10 @@ class VerificationRule(AbstractRule[CombinatorialClassType, CombinatorialObjectT
             "VerificationStrategy[CombinatorialClassType, CombinatorialObjectType]",
             super().strategy,
         )
+
+    @staticmethod
+    def is_equivalence() -> bool:
+        return False
 
     def count_objects_of_size(self, n: int, **parameters: int) -> int:
         key = (n,) + tuple(sorted(parameters.items()))


### PR DESCRIPTION
The current outline is broken due to the need for the RecomputingDict to know if two labels are equivalent.