### PR TITLE
ignore rules where the left and non-empty right hand sides are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- ignore rules where the left and non-empty right hand sides are the same
 
 ## [1.2.0] - 2020-06-29
 ### Added

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -312,6 +312,9 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
 
             cleaned_end_labels.append(child_label)
 
+        if cleaned_end_labels == [start_label]:
+            return
+
         if rule.ignore_parent:
             self._stop_yielding(start_label)
 


### PR DESCRIPTION
### Fixed
- ignore rules where the left and non-empty right hand sides are the same