### PR TITLE
add fixed values to DisjointUnion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- added an optional `fixed_values` parameter to the `DisjointUnion` constructor,
+  that allows you to set a value that a child's parameter must take.
+
 ### Fixed
 - ignore rules where the left and non-empty right hand sides are the same
 

--- a/comb_spec_searcher/strategies/constructor.py
+++ b/comb_spec_searcher/strategies/constructor.py
@@ -269,8 +269,8 @@ class DisjointUnion(Constructor[CombinatorialClassType, CombinatorialObjectType]
     If a parents variable does not map to a child, then this variable must be 0
     as the child contains no occurences.
 
-    The zeroes are a tuple of parameters for each child which must take a value
-    of zero.
+    The fixed value dictionaries passed will be used ensure that the parameter
+    of a child must take on the given value.
     """
 
     def __init__(

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -390,7 +390,10 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
             assert (
                 self.subrecs is not None
             ), "you must call the set_subrecs function first"
-            res = self.constructor.get_recurrence(self.subrecs, n, **parameters)
+            try:
+                res = self.constructor.get_recurrence(self.subrecs, n, **parameters)
+            except AssertionError:
+                raise ValueError(f"issue with rule:\n {self}")
             self.count_cache[key] = res
         #     # THE FOLLOWING CODE SNIPPET IS FOR DEBUGGING PURPOSES
         #     if self.comb_class.extra_parameters:
@@ -557,8 +560,6 @@ class EquivalencePathRule(Rule[CombinatorialClassType, CombinatorialObjectType])
     @property
     def constructor(self) -> DisjointUnion:
         if self._constructor is None:
-            if not self.comb_class.extra_parameters:
-                return DisjointUnion(self.comb_class, self.children)
             extra_parameters: Dict[str, str] = {
                 k: k for k in self.comb_class.extra_parameters
             }
@@ -571,8 +572,13 @@ class EquivalencePathRule(Rule[CombinatorialClassType, CombinatorialObjectType])
                     for parent_var, child_var in extra_parameters.items()
                     if child_var in rules_parameters
                 }
+            fixed_values = {
+                k: 0
+                for k in self.children[0].extra_parameters
+                if k not in extra_parameters.values()
+            }
             self._constructor = DisjointUnion(
-                self.comb_class, self.children, (extra_parameters,)
+                self.comb_class, self.children, (extra_parameters,), (fixed_values,)
             )
         return self._constructor
 
@@ -674,8 +680,13 @@ class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
             flipped_extra_params = {
                 b: a for a, b in original_constructor.extra_parameters[0].items()
             }
+            fixed_values = {
+                k: 0
+                for k in self.children[0].extra_parameters
+                if k not in flipped_extra_params.values()
+            }
             self._constructor = DisjointUnion(
-                self.comb_class, self.children, (flipped_extra_params,)
+                self.comb_class, self.children, (flipped_extra_params,), (fixed_values,)
             )
         return self._constructor
 

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -194,11 +194,17 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
         def brute_force_count(
             comb_class: CombinatorialClassType, n: int, **parameters
         ) -> int:
+            assert set(comb_class.extra_parameters) == set(
+                parameters
+            ), f"{comb_class.extra_parameters, set(parameters)}"
             return len(list(comb_class.objects_of_size(n, **parameters)))
 
         def brute_force_generation(
             comb_class: CombinatorialClassType, n: int, **parameters: int
         ) -> Iterator[CombinatorialObjectType]:
+            assert set(comb_class.extra_parameters) == set(
+                parameters
+            ), f"{comb_class.extra_parameters, set(parameters)}"
             yield from comb_class.objects_of_size(n, **parameters)
 
         actual_count = brute_force_count(self.comb_class, n, **parameters)


### PR DESCRIPTION
### Added
- added an optional `fixed_values` parameter to the `DisjointUnion` constructor,
  that allows you to set a value that a child's parameter must take.