### PR TITLE
changes expand_verified search to auto_search instead of do_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - ignore rules where the left and non-empty right hand sides are the same
 
+### Changed
+- When expanding verified nodes in a specification, the search now uses `auto_search`,
+  instead of `do_level` and `get_smallest_specification`.
+
 ## [1.2.0] - 2020-06-29
 ### Added
 - Support for maple equations in multiple variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - When expanding verified nodes in a specification, the search now uses `auto_search`,
   instead of `do_level` and `get_smallest_specification`.
+- `auto_search`now has an option `raw_rules` to return only the rules and equivalence
+  paths instead of a specification.
 
 ## [1.2.0] - 2020-06-29
 ### Added

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -21,8 +21,6 @@ from .combinatorial_class import (
 from .exception import (
     IncorrectGeneratingFunctionError,
     InvalidOperationError,
-    NoMoreClassesToExpandError,
-    SpecificationNotFound,
     TaylorExpansionError,
 )
 from .strategies import (

--- a/comb_spec_searcher/strategies/strategy.py
+++ b/comb_spec_searcher/strategies/strategy.py
@@ -541,7 +541,7 @@ class VerificationStrategy(
         assert specification is not None, StrategyDoesNotApply(
             "Cannot find a specification"
         )
-        return specification
+        return cast("CombinatorialSpecification", specification)
 
     def get_genf(
         self,

--- a/example.py
+++ b/example.py
@@ -36,13 +36,14 @@ with respect to factor order is given.
 9798
 """
 from itertools import product
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union, cast
 
 from comb_spec_searcher import (
     AtomStrategy,
     CartesianProductStrategy,
     CombinatorialClass,
     CombinatorialObject,
+    CombinatorialSpecification,
     CombinatorialSpecificationSearcher,
     DisjointUnionStrategy,
     StrategyPack,
@@ -332,7 +333,7 @@ if __name__ == "__main__":
 
     start_class = AvoidingWithPrefix(Word(), example_patterns, example_alphabet)
     searcher = CombinatorialSpecificationSearcher(start_class, pack, debug=True)
-    spec = searcher.auto_search(status_update=10)
+    spec = cast(CombinatorialSpecification, searcher.auto_search(status_update=10))
     print(spec)
     print(spec.get_genf())
     import time


### PR DESCRIPTION
The main purpose of this is to search for a "smallish" tree, not the "smallest". When expanding Av(1234, 4321), the universe is far too big to look for the smallest tree.