### PR TITLE
fixes sanity checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed sanity checking in `comb_spec_searcher`
 
 ## [1.3.0] - 2020-07-07
 ### Added
@@ -15,8 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - removed the method `is_equivalence` from `Constructor`. You should instead
   use the `is_equivalence` method on the `Rule`.
-
-### Changed
 - the `CartesianProduct` now considers compositions of all parameters and
   not just `n`.
 - the `RelianceProfile` type changed to work multiple parameters. It is now a

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -251,9 +251,9 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
                 )
                 try:
                     n = 4
-                    # TODO: test for multiple variable
                     for i in range(n + 1):
-                        rule.sanity_check(n=i)
+                        for parameters in rule.comb_class.possible_parameters(i):
+                            rule.sanity_check(n=i, **parameters)
                     logger.debug("Sanity checked rule to length %s.", n)
                 except NotImplementedError as e:
                     logger.debug(


### PR DESCRIPTION
The snippet for sanity checking that accounts for extra parameters was missing in `comb_spec_searcher.py`.