### PR TITLE
move `get_eq_symbol` and `get_op_symbol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `_auto_search_rules`, instead of `do_level` and `get_smallest_specification`.
   This is a stripped back auto search method returning the equivalence paths
   and strategies needed to create a specification.
+- the `get_eq_symbol` and `get_op_symbol` are moved to `AbstractStrategy`
+  rather than `Constructor`
 
 ### Fixed
 - fixed sanity checking in `comb_spec_searcher`

--- a/comb_spec_searcher/strategies/constructor.py
+++ b/comb_spec_searcher/strategies/constructor.py
@@ -69,22 +69,6 @@ class Constructor(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectTy
         """Return a randomly sampled subobjs/image of the bijection implied
         by the constructor."""
 
-    @staticmethod
-    def get_eq_symbol() -> str:
-        """
-        Return a choice for '=' in the pretty print a '=' b '+' c of rules.
-        Your choice should be a single charachter.
-        """
-        return "="
-
-    @staticmethod
-    def get_op_symbol() -> str:
-        """
-        Return a choice for '+' in the pretty print a '=' b '+' c of rules.
-        Your choice should be a single charachter.
-        """
-        return "+"
-
 
 class CartesianProduct(Constructor[CombinatorialClassType, CombinatorialObjectType]):
     """

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -291,7 +291,7 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
             symbol_height = 1
             eq_symbol = (
                 ["     " for i in range(symbol_height)]
-                + ["  {}  ".format(self.constructor.get_eq_symbol())]
+                + ["  {}  ".format(self.strategy.get_eq_symbol())]
                 + ["     " for i in range(symbol_height)]
             )
             join(res, eq_symbol)
@@ -299,7 +299,7 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
             if len(children) > 1:
                 op_symbol = (
                     ["     " for i in range(symbol_height)]
-                    + ["  {}  ".format(self.constructor.get_op_symbol())]
+                    + ["  {}  ".format(self.strategy.get_op_symbol())]
                     + ["     " for i in range(symbol_height)]
                 )
                 for child in children[1:]:

--- a/comb_spec_searcher/strategies/strategy.py
+++ b/comb_spec_searcher/strategies/strategy.py
@@ -186,6 +186,22 @@ class AbstractStrategy(
         Return a short string to explain what the strategy has done.
         """
 
+    @staticmethod
+    def get_eq_symbol() -> str:
+        """
+        Return a choice for '=' in the pretty print a '=' b '+' c of rules.
+        Your choice should be a single charachter.
+        """
+        return "="
+
+    @staticmethod
+    def get_op_symbol() -> str:
+        """
+        Return a choice for '+' in the pretty print a '=' b '+' c of rules.
+        Your choice should be a single charachter.
+        """
+        return "+"
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AbstractStrategy):
             return NotImplemented
@@ -388,6 +404,14 @@ class CartesianProductStrategy(
             extra_parameters=self.extra_parameters(comb_class, children),
         )
 
+    @staticmethod
+    def get_op_symbol() -> str:
+        """
+        Return a choice for '+' in the pretty print a '=' b '+' c of rules.
+        Your choice should be a single charachter.
+        """
+        return "x"
+
 
 class DisjointUnionStrategy(Strategy[CombinatorialClassType, CombinatorialObjectType]):
     """
@@ -459,6 +483,14 @@ class DisjointUnionStrategy(Strategy[CombinatorialClassType, CombinatorialObject
             children = self.decomposition_function(comb_class)
         idx = DisjointUnionStrategy.backward_map_index(objs)
         return cast(CombinatorialObjectType, objs[idx])
+
+    @staticmethod
+    def get_op_symbol() -> str:
+        """
+        Return a choice for '+' in the pretty print a '=' b '+' c of rules.
+        Your choice should be a single charachter.
+        """
+        return "+"
 
 
 class SymmetryStrategy(


### PR DESCRIPTION
### Changed
- the `get_eq_symbol` and `get_op_symbol` are moved to `AbstractStrategy`
  rather than `Constructor`