### PR TITLE
expand verified only after specs are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- the methods `expand_verified` and `expand_comb_class` on
+  `CombinatorialSpecification`
+- the `get_rule` method on `CombinatorialSpecification` can also take a label
+  as a key
+
 ### Changed
 - When expanding verified nodes in a specification, the search now uses
   `_auto_search_rules`, instead of `do_level` and `get_smallest_specification`.
@@ -12,6 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and strategies needed to create a specification.
 - the `get_eq_symbol` and `get_op_symbol` are moved to `AbstractStrategy`
   rather than `Constructor`
+- the `expand_verified` flag on the `auto_search` method and
+  `CombinitorialSpecification.__init__` method was removed, and the
+  default is now to not expand verified classes. You should use the
+  `expand_verified` method on `CombinatorialSpecification` for the same
+  behaviour.
+  It also no longer logs the string of the specification.
 
 ### Fixed
 - fixed sanity checking in `comb_spec_searcher`

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -521,7 +521,9 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             round(time.time() - start_time, 2)
         )
         found_string += self.status(elaborate=True)
-        found_string += str(specification)
+        found_string += (
+            f"Specification found has {specification.number_of_rules()} rules"
+        )
         logger.info(found_string, extra=self.logger_kwargs)
 
     def _log_status(self, start_time: float, status_update: int) -> None:
@@ -567,9 +569,6 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
 
         If 'smallest' is set to 'True' then the searcher will return a proof
         tree that is as small as possible.
-
-        If 'expand_verified' is set to 'False' then the searcher will not
-        expand verified classes.
         """
         auto_search_start = time.time()
 
@@ -604,7 +603,6 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             logger.debug("Searching for specification.", extra=self.logger_kwargs)
             specification = self.get_specification(
                 smallest=kwargs.get("smallest", False),
-                expand_verified=kwargs.get("expand_verified", True),
                 minimization_time_limit=0.01 * (time.time() - auto_search_start),
             )
             if specification is not None:
@@ -690,10 +688,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
 
     @cssmethodtimer("get specification")
     def get_specification(
-        self,
-        minimization_time_limit: float = 10,
-        smallest: bool = False,
-        expand_verified: bool = True,
+        self, minimization_time_limit: float = 10, smallest: bool = False,
     ) -> Optional[CombinatorialSpecification]:
         """
         Return a CombinatorialSpecification if the universe contains one.
@@ -712,10 +707,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
             "Creating a specification", extra=self.logger_kwargs,
         )
         return CombinatorialSpecification(
-            start_class,
-            strategies,
-            comb_class_eqv_paths,
-            expand_verified=expand_verified,
+            start_class, strategies, comb_class_eqv_paths,
         )
 
     @cssmethodtimer("get specification")

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -186,9 +186,9 @@ class CombinatorialSpecification(
                     " in the specification."
                 )
         if comb_class not in self.rules_dict:
-            if comb_class.is_empty():
-                empty_strat = EmptyStrategy()
-                self.rules_dict[comb_class] = empty_strat(comb_class)
+            assert comb_class.is_empty(), "rule not in the spec and not empty"
+            empty_strat = EmptyStrategy()
+            self.rules_dict[comb_class] = empty_strat(comb_class)
         return self.rules_dict[comb_class]
 
     @property

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -105,7 +105,7 @@ class CombinatorialSpecification(
 
     def expand_verified(self) -> None:
         """
-        Will expand all verified classes with respect to the strategy pack
+        Will expand all verified classes with respect to the strategy packs
         given by the VerificationStrategies.
         """
         verification_packs: Dict[CombinatorialClassType, StrategyPack] = {}
@@ -115,9 +115,11 @@ class CombinatorialSpecification(
                     verification_packs[comb_class] = rule.pack()
                 except InvalidOperationError:
                     logger.info("Can't expand the rule:\n%s", rule)
-        for comb_class in verification_packs:
-            self.rules_dict.pop(comb_class)
-        self._expand_verified_comb_classes(verification_packs)
+        if verification_packs:
+            for comb_class in verification_packs:
+                self.rules_dict.pop(comb_class)
+            self._expand_verified_comb_classes(verification_packs)
+            self.expand_verified()
 
     def expand_comb_class(self, comb_class: Union[int, CombinatorialClassType]) -> None:
         """
@@ -181,7 +183,7 @@ class CombinatorialSpecification(
             try:
                 comb_class = self._label_to_tiling[comb_class]
             except KeyError:
-                raise KeyError(
+                raise InvalidOperationError(
                     f"The label {comb_class} does not correspond to a tiling"
                     " in the specification."
                 )


### PR DESCRIPTION
### Added
- the methods `expand_verified` and `expand_comb_class` on
  `CombinatorialSpecification`
- the `get_rule` method on `CombinatorialSpecification` can also take a label
  as a key

### Changed
- the `expand_verified` flag on the `auto_search` method and
  `CombinitorialSpecification.__init__` method was removed, and the
  default is now to not expand verified classes. You should use the
  `expand_verified` method on `CombinatorialSpecification` for the same
  behaviour.
  It also no longer logs the string of the specification.