### PR TITLE
avoid looping over all rules when finding a spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `rule_from_equivalence_rule_dict` to `RuleDBBase`
 ### Changed
 - When expanding verified nodes in a specification, the search now uses
   `_auto_search_rules`, instead of `do_level` and `get_smallest_specification`.


### PR DESCRIPTION
### Added
- `rule_from_equivalence_rule_dict` to `RuleDBBase`