### PR TITLE
Share spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `show` method to `CombinatorialSpecification`
 - `to_html_representation` method to `CombinatorialClass`
 - `AbstractStrategy` raises `StrategyDoesNotApply` in the `__call__` method
+- function `CombinatorialSpecification.share_spec()` which uploads the spec to a file
+  sharing site
 
 ### Changed
 - Improved the status update

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -448,6 +448,20 @@ class CombinatorialSpecification(
         )
         sd.show()
 
+    def share(self, levels_shown: int = 0, levels_expand: int = 0) -> None:
+        """
+        Displays a tree representing this object in the web browser
+        OTHER INPUT:
+            - 'levels_shown': number of levels displayed at the start.
+            If 0 then the whole tree is displayed
+            - 'levels_expand': number of levels displayed after expanding a node.
+            If 0 then the rest of the tree is displayed
+        """
+        sd = SpecificationDrawer(
+            self, levels_shown=levels_shown, levels_expand=levels_expand
+        )
+        sd.share()
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CombinatorialSpecification):
             return NotImplemented

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -454,8 +454,10 @@ class CombinatorialSpecification(
 
     def share(self, levels_shown: int = 0, levels_expand: int = 0) -> None:
         """
-        Displays a tree representing this object in the web browser
-        OTHER INPUT:
+        Uploads the html representation of the specification to a sharing website and
+        display the link to the file.
+
+        INPUT:
             - 'levels_shown': number of levels displayed at the start.
             If 0 then the whole tree is displayed
             - 'levels_expand': number of levels displayed after expanding a node.

--- a/comb_spec_searcher/specification_drawer.py
+++ b/comb_spec_searcher/specification_drawer.py
@@ -10,6 +10,7 @@ import webbrowser
 from copy import copy
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Tuple
 
+import requests
 from logzero import logger
 from typing_extensions import TypedDict
 
@@ -354,6 +355,37 @@ class SpecificationDrawer:
         html_string = self.to_html()
         viewer = HTMLViewer()
         viewer.open_html(html_string)
+
+    def share(self) -> None:
+        """
+        Displays CombinatorialSpecification tree in the web browser
+        """
+        html_string = self.to_html()
+
+        with tempfile.NamedTemporaryFile(
+            "r+", suffix=".html", delete=False, encoding="UTF8"
+        ) as html_file:
+            html_file.write(html_string)
+            file_path = html_file.name
+
+        # ask gofile.io which server it wants us to use
+        logger.info("Sending specification to file host.")
+        req1 = requests.get("https://apiv2.gofile.io/getServer")
+        server = req1.json()["data"]["server"]
+        upload_url = f"https://{server}.gofile.io/upload"
+
+        with open(file_path, "rb") as f:
+            req2 = requests.post(upload_url, files={"filesUploaded": f},)
+
+        os.remove(file_path)
+        file_code = req2.json()["data"]["code"]
+        file_name = file_path.split("/")[-1]
+
+        file_enable_url = f"https://gofile.io/d/{file_code}"
+        file_url = f"https://{server}.gofile.io/download/{file_code}/{file_name}"
+
+        print(f"First click this: {file_enable_url}")
+        print(f"Then this link will work: {file_url}")
 
 
 class HTMLViewer:

--- a/comb_spec_searcher/specification_drawer.py
+++ b/comb_spec_searcher/specification_drawer.py
@@ -358,7 +358,8 @@ class SpecificationDrawer:
 
     def share(self) -> None:
         """
-        Displays CombinatorialSpecification tree in the web browser
+        Upload the html of the specification on a file server and displays a link to the
+        file.
         """
         html_string = self.to_html()
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "sympy==1.6.1",
         "psutil==5.7.2",
         "pympler==0.8",
+        "requests==2.24.0",
         "typing-extensions==3.7.4.2",
         "tabulate==0.8.7",
     ],


### PR DESCRIPTION
Uploads the spec to a file sharing website. It's a bit hacky. It displays a message like this
```
First click this: https://gofile.io/d/XXYczX
Then this link will work: https://srv-file19.gofile.io/download/XXYczX/tmp9yflowpo.html
```

I had to add `requests` as a requirement.