### PR TITLE
reformatting the build_param_map function

### DIFF
--- a/comb_spec_searcher/strategies/constructor.py
+++ b/comb_spec_searcher/strategies/constructor.py
@@ -107,7 +107,7 @@ class Constructor(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectTy
             for pos, value in enumerate(param):
                 parent_pos = child_pos_to_parent_pos[pos]
                 for p in parent_pos:
-                    new_params[p] = value
+                    new_params[p] += value
             return tuple(new_params)
 
         return param_map


### PR DESCRIPTION
I've noticed that we implemented the `_build_param_map` method independently for
each constructor while they were basically the same. I've made the adjustment to
have a single `_build_param_map` method on the `Constructor` class.
