### PR TITLE
CI update for 3.9

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,10 @@ jobs:
             os: ubuntu-latest
 
           - python: 3.9
-            toxenv: py38
+            toxenv: py39
             os: macos-latest
           - python: 3.9
-            toxenv: py38
+            toxenv: py39
             os: windows-latest
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python: 3.8
+          - python: 3.9
             toxenv: flake8
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: mypy
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: pylint
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: black
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: tilescope
             os: ubuntu-latest
 
@@ -34,17 +34,20 @@ jobs:
           - python: 3.8
             toxenv: py38
             os: ubuntu-latest
-          - python: 3.9-dev
+          - python: 3.9
             toxenv: py39
+            os: ubuntu-latest
+          - python: 3.10-dev
+            toxenv: py310
             os: ubuntu-latest
           - python: pypy3
             toxenv: pypy36
             os: ubuntu-latest
 
-          - python: 3.8
+          - python: 3.9
             toxenv: py38
             os: macos-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: py38
             os: windows-latest
 

--- a/comb_spec_searcher/__init__.py
+++ b/comb_spec_searcher/__init__.py
@@ -16,6 +16,8 @@ from .strategies import (
     VerificationStrategy,
 )
 
+__version__ = "2.4.0"
+
 __all__ = [
     "CombinatorialSpecificationSearcher",
     "CombinatorialClass",

--- a/comb_spec_searcher/typing.py
+++ b/comb_spec_searcher/typing.py
@@ -42,6 +42,7 @@ RulesDict = Dict[int, Set[Tuple[int, ...]]]
 
 
 class WorkPacket(NamedTuple):
+    # pylint: disable=inherit-non-class
     label: int
     strategies: Tuple[CSSstrategy, ...]
     inferral: bool

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,17 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(
     name="comb_spec_searcher",
-    version="2.4.0",
+    version=get_version("comb_spec_searcher/__init__.py"),
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="A library for performing combinatorial exploration.",
@@ -21,7 +29,7 @@ setup(
         "Source": "https://github.com/PermutaTriangle/comb_spec_searcher",
         "Tracker": ("https://github.com/PermutaTriangle/comb_spec_searcher" "/issues"),
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={"comb_spec_searcher": ["py.typed"]},
     long_description=read("README.rst"),
     python_requires=">=3.6",
@@ -35,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Education",

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@
 [tox]
 envlist =
     flake8, mypy, pylint, black, tilescope
-    py{36,37,38,39},
+    py{36,37,38,39,310},
     pypy36
 
 [default]
-basepython=python3.8
+basepython=python3.9
 
 [testenv]
 description = run test
@@ -19,6 +19,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy36: pypy3
 deps =
     pytest==6.1.2


### PR DESCRIPTION
* 3.9 as default
* 3.10 dev builds
* version in `comb_spec_searcher/__init__.py`
* stop packaging test modules