### PR TITLE
prints warning if rule in a spec can't be sanity checked, instead of raising exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `find_bijection_between` tries to find a bijection between classes given
   a `CombinatorialSpecificationSearcher` object for both.
 
+### Changed
+- If a rule in a specification cannot be sanity checked (e.g., counting is not
+  implemented), a warning is printed and sanity checking continues, instead of returning
+  the exception.
+
 ### Fixed
 - Removed a debug print
 - Sharing of a specification html via gofile API.

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -443,10 +443,23 @@ class CombinatorialSpecification(
 
         Raise an SanityCheckFailure error if it fails.
         """
-        return self._is_valid_spec() and all(
-            all(rule.sanity_check(n) for rule in self.rules_dict.values())
-            for n in range(length + 1)
-        )
+        if not self._is_valid_spec():
+            return False
+
+        for rule in self.rules_dict.values():
+            try:
+                for n in range(length + 1):
+                    if not rule.sanity_check(n):
+                        return False
+            except NotImplementedError:
+                logger.warning(
+                    "Can't sanity check the rule %s -> %s, which is\n" "%s",
+                    self.get_label(rule.comb_class),
+                    tuple(self.get_label(child) for child in rule.children),
+                    rule,
+                )
+
+        return True
 
     def get_bijection_to(
         self, other: "CombinatorialSpecification"


### PR DESCRIPTION
Looks like this now:
```python
In [1]: spec.sanity_check(5)
[W 210416 11:17:59 specification:459] Can't sanity check the rule 2 -> (), which is
    tiling is a subclass of the original tiling
    +-+
    |1|
    +-+
    1: Av(1302, 2031, 3120)
    Assumption 0:
    can count points in cell (0, 0)
[W 210416 11:18:09 specification:459] Can't sanity check the rule 5 -> (), which is
    tiling is a subclass of the original tiling
    +-+
    |1|
    +-+
    1: Av(0231, 1230)
```