### PR TITLE
fix the formal step of reverse equiv rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   pickled.
 - Fix bug in complement constructor counting
 - Fixing a bug in counting for equivalence rule from a reverse rule
+- Fixing in the formal step of reverse equivalence rule. The formal step now
+  state that the rule is reversed.
 
 ### Deprecated
 - Python 3.6 is no longer supported

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -2,8 +2,6 @@
 The rule class is used for a specific application of a strategy on a combinatorial
 class. This is not something the user should implement, as it is just a wrapper for
 calling the Strategy class and storing its results.
-
-A CombinatorialSpecification is (more or less) a set of Rule.
 """
 import abc
 import random
@@ -50,7 +48,8 @@ __all__ = ("Rule", "VerificationRule")
 
 class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectType]):
     """
-    An instance of Rule is created by the __call__ method of strategy.
+    An application of a strategy to a comb_class. If the children are not provided they
+    are computed from the strategy.
     """
 
     def __init__(
@@ -258,7 +257,6 @@ class AbstractRule(abc.ABC, Generic[CombinatorialClassType, CombinatorialObjectT
 
         Raise a SanityCheckFailure error if the sanity_check fails.
         """
-        raise NotImplementedError
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AbstractRule):
@@ -396,8 +394,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
 
     def to_equivalence_rule(self) -> "EquivalenceRule":
         """
-        Return the reverse rule. At this stage, reverse rules can only be
-        created for equivalence rules.
+        Return the version of the rule where the empty children are removed.
         """
         assert (
             self.is_equivalence()
@@ -406,8 +403,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
 
     def to_reverse_rule(self, idx: int) -> "Rule":
         """
-        Return the reverse rule. At this stage, reverse rules can only be
-        created for equivalence rules.
+        Return the reverse rule where the child at the given index is the parent.
         """
         return ReverseRule(self, idx)
 
@@ -613,10 +609,6 @@ class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
 
     @property
     def constructor(self) -> Union[DisjointUnion, Complement]:
-        """
-        Return the constructor, that contains all the information about how to
-        count/generate objects from the rule.
-        """
         if self._constructor is None:
             original_constructor = self.original_rule.constructor
             if isinstance(original_constructor, DisjointUnion):
@@ -827,10 +819,6 @@ class EquivalencePathRule(Rule[CombinatorialClassType, CombinatorialObjectType])
 
 
 class ReverseRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
-    """
-    A class for creating a reverse equivalence rule.
-    """
-
     def __init__(
         self, rule: Rule[CombinatorialClassType, CombinatorialObjectType], idx: int
     ):

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -660,9 +660,15 @@ class EquivalenceRule(Rule[CombinatorialClassType, CombinatorialObjectType]):
 
     @property
     def formal_step(self) -> str:
-        return "{} but only the child at index {} is non-empty".format(
-            self.strategy.formal_step(), self.child_idx
-        )
+        strat = self.strategy.formal_step()
+        if isinstance(self.original_rule, ReverseRule):
+            idx = self.original_rule.idx
+        else:
+            idx = self.child_idx
+        s = f"{strat} but only child and index {idx} is non-empty"
+        if isinstance(self.original_rule, ReverseRule):
+            return f"reverse of '{s}'"
+        return s
 
     def backward_map(
         self, objs: Tuple[Optional[CombinatorialObjectType], ...]

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -5,6 +5,7 @@ from example import AvoidingWithPrefix, ExpansionStrategy
 def test_reverse_equivalence():
     comb_class = AvoidingWithPrefix("aaa", ["aaaa"], "a", False)
     rule = ExpansionStrategy()(comb_class)
+    eqv_rule = rule.to_equivalence_rule()
     assert len(rule.non_empty_children()) == 1
     equiv_then_reverse = rule.to_equivalence_rule().to_reverse_rule(0)
     assert equiv_then_reverse.is_equivalence()
@@ -16,3 +17,10 @@ def test_reverse_equivalence():
     assert reverse_then_equiv.children == (comb_class,)
     assert reverse_then_equiv.comb_class == rule.non_empty_children()[0]
     assert isinstance(reverse_then_equiv, EquivalenceRule)
+    print(rule)
+    assert (
+        eqv_rule.formal_step == "Either just the prefix, or append a"
+        " letter from the alphabet but only child and index 0 is non-empty"
+    )
+    assert reverse_then_equiv.formal_step == f"reverse of '{eqv_rule.formal_step}'"
+    assert equiv_then_reverse.formal_step == f"reverse of '{eqv_rule.formal_step}'"

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -17,7 +17,6 @@ def test_reverse_equivalence():
     assert reverse_then_equiv.children == (comb_class,)
     assert reverse_then_equiv.comb_class == rule.non_empty_children()[0]
     assert isinstance(reverse_then_equiv, EquivalenceRule)
-    print(rule)
     assert (
         eqv_rule.formal_step == "Either just the prefix, or append a"
         " letter from the alphabet but only child and index 0 is non-empty"


### PR DESCRIPTION
The formal step of reverse equiv rule didn't state that the rule was a reverse
rule. This is now fixed.
