### PR TITLE
forest rule extractor doesn't return empty rule

### DIFF
--- a/comb_spec_searcher/rule_db/forest.py
+++ b/comb_spec_searcher/rule_db/forest.py
@@ -441,9 +441,13 @@ class ForestRuleExtractor:
     def rules(self) -> Iterator[AbstractRule]:
         """
         Return all the rules of the specification.
+
+        The empty rule are ignored as they be produced as needed by the specification.
         """
         for rk in self.needed_rules:
             rule = self._find_rule(rk)
+            if isinstance(rule.strategy, EmptyStrategy):
+                continue
             if rule.is_equivalence():
                 assert isinstance(rule, Rule)
                 yield rule.to_equivalence_rule()


### PR DESCRIPTION
Since the specification create the empty rule as needed we don't need to return
them from the extractor.

This avoid sending rule that are not used by the final spec once empty children
are removed.
