### PR TITLE
Expansion with reverse and ignore parent on verification strategy

### DIFF
--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -143,7 +143,9 @@ class CombinatorialSpecification(
             rule = new_spec.rules_dict[class_to_expand]
             assert isinstance(rule, VerificationRule)
             pack = rule.pack()
-            new_spec = new_spec.expand_comb_class(class_to_expand, pack, reverse=False)
+            new_spec = new_spec.expand_comb_class(
+                class_to_expand, pack, reverse=False, continue_expanding_verified=False
+            )
 
     def unexpanded_verified_classes(self) -> Iterator[CombinatorialClassType]:
         """
@@ -163,6 +165,7 @@ class CombinatorialSpecification(
         comb_class: Union[int, CombinatorialClassType],
         pack: StrategyPack,
         reverse: bool,
+        continue_expanding_verified: bool,
         max_expansion_time: Optional[float] = None,
     ) -> "CombinatorialSpecification[CombinatorialClassType, CombinatorialObjectType]":
         """
@@ -182,7 +185,11 @@ class CombinatorialSpecification(
         )
         ruledb = RuleDBForest(reverse=False, rule_cache=spec_rules)
         css = CombinatorialSpecificationSearcher(
-            self.root, pack, ruledb=ruledb, debug=False
+            self.root,
+            pack,
+            ruledb=ruledb,
+            debug=False,
+            expand_verified=continue_expanding_verified,
         )
         for rule in spec_rules:
             start_label = css.classdb.get_label(rule.comb_class)

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -172,6 +172,9 @@ class CombinatorialSpecification(
         Will try to expand a particular class with respect to the given strategy pack.
 
         If reverse is set to True, will allow to use reverse rule in the expansion.
+
+        If continue continue_expanding_verified is set to True then the css will keep
+        working on verified classes when performing the search.
         """
         # pylint: disable=import-outside-toplevel
         from .comb_spec_searcher import CombinatorialSpecificationSearcher

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -143,7 +143,7 @@ class CombinatorialSpecification(
             rule = new_spec.rules_dict[class_to_expand]
             assert isinstance(rule, VerificationRule)
             pack = rule.pack()
-            new_spec = new_spec.expand_comb_class(class_to_expand, pack)
+            new_spec = new_spec.expand_comb_class(class_to_expand, pack, reverse=False)
 
     def unexpanded_verified_classes(self) -> Iterator[CombinatorialClassType]:
         """
@@ -162,10 +162,13 @@ class CombinatorialSpecification(
         self,
         comb_class: Union[int, CombinatorialClassType],
         pack: StrategyPack,
+        reverse: bool,
         max_expansion_time: Optional[float] = None,
     ) -> "CombinatorialSpecification[CombinatorialClassType, CombinatorialObjectType]":
         """
         Will try to expand a particular class with respect to the given strategy pack.
+
+        If reverse is set to True, will allow to use reverse rule in the expansion.
         """
         # pylint: disable=import-outside-toplevel
         from .comb_spec_searcher import CombinatorialSpecificationSearcher
@@ -185,6 +188,7 @@ class CombinatorialSpecification(
             start_label = css.classdb.get_label(rule.comb_class)
             end_labels = tuple(map(css.classdb.get_label, rule.children))
             ruledb.add(start_label, end_labels, rule)
+        ruledb.reverse = reverse
         css.classqueue = DefaultQueue(css.strategy_pack)
         css.classqueue.add(css.classdb.get_label(comb_class))
         # logger.info(CSS.run_information())

--- a/comb_spec_searcher/strategies/strategy.py
+++ b/comb_spec_searcher/strategies/strategy.py
@@ -665,7 +665,7 @@ class VerificationStrategy(
     AtomStrategy, relying on CombinatorialClass methods.
     """
 
-    def __init__(self, ignore_parent: bool = True):
+    def __init__(self, ignore_parent: bool = False):
         super().__init__(
             ignore_parent=ignore_parent,
             inferrable=False,


### PR DESCRIPTION
- make verification strategy not ignore parent
- allow to expand comb class with reverse rule
