### PR TITLE
strategic gc.collect while minimizing forest

### DIFF
--- a/comb_spec_searcher/rule_db/forest.py
+++ b/comb_spec_searcher/rule_db/forest.py
@@ -514,12 +514,16 @@ class ForestRuleExtractor:
             # pylint: disable=undefined-loop-variable
             for _ in range(i, len(minimizing)):
                 minimizing.pop()
+            # added to avoid doubling in memory when minimizing with pypy
+            gc.collect()
         counter = 0
         while maybe_useful:
             rk = maybe_useful.pop()
             if not self._is_productive(itertools.chain.from_iterable(not_minimizing)):
                 self.needed_rules.append(rk)
                 counter += 1
+            # added to avoid doubling in memory when minimizing with pypy
+            gc.collect()
         logger.info("Using %s rule for %s", counter, key.name)
 
     def _is_productive(self, rule_keys: Iterable[ForestRuleKey]) -> bool:

--- a/comb_spec_searcher/rule_db/forest.py
+++ b/comb_spec_searcher/rule_db/forest.py
@@ -1,3 +1,4 @@
+import gc
 import itertools
 import time
 from datetime import timedelta


### PR DESCRIPTION
This avoid a doubling of memory we where seeing with pypy when
minimizing a forest.
