### PR TITLE
skipping sanity check if not implemented, or spec not found

### DIFF
--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -335,12 +335,13 @@ class CombinatorialSpecification(
                     eq = rule.get_equation(self.get_function)
                 if not isinstance(eq, bool):
                     yield eq
-            except NotImplementedError:
+            except NotImplementedError as e:
                 logger.info(
-                    "can't find generating function for the rule %s -> %s. "
+                    "can't find generating function for the rule %s -> %s. Reason: %s"
                     "The rule was:\n%s",
                     self.get_label(rule.comb_class),
                     tuple(self.get_label(child) for child in rule.children),
+                    e,
                     rule,
                 )
                 x = var("x")

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -538,7 +538,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         try:
             rule_terms = self.get_terms(n)
         except (NotImplementedError, SpecificationNotFound) as e:
-            logger.warning(f"Skipping sanitiy checking counts for rule\n{self}\n{e}")
+            logger.warning("Skipping sanitiy checking counts for rule\n%s\n%s", self, e)
             return True
         self.subterms = temp_subterms
         if actual_terms != rule_terms:
@@ -564,7 +564,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
             rule_objects = self.get_objects(n)
         except (NotImplementedError, SpecificationNotFound) as e:
             logger.warning(
-                f"Skipping sanitiy checking generation for rule\n{self}\n{e}"
+                "Skipping sanitiy checking generation for rule\n%s\n%s", self, e
             )
             return True
         self.subobjects = tempobjects
@@ -1141,5 +1141,5 @@ class VerificationRule(AbstractRule[CombinatorialClassType, CombinatorialObjectT
         try:
             return self.get_terms(n) == self.comb_class.get_terms(n)
         except (NotImplementedError, SpecificationNotFound) as e:
-            logger.warning(f"Skipping sanitiy checking counts for rule\n{self}\n{e}")
+            logger.warning("Skipping sanitiy checking counts for rule\n%s\n%s", self, e)
             return True

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -538,7 +538,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         try:
             rule_terms = self.get_terms(n)
         except (NotImplementedError, SpecificationNotFound) as e:
-            logger.warning("Skipping sanitiy checking counts for rule\n%s\n%s", self, e)
+            logger.warning("Skipping sanity checking counts for rule\n%s\n%s", self, e)
             return True
         self.subterms = temp_subterms
         if actual_terms != rule_terms:
@@ -564,7 +564,7 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
             rule_objects = self.get_objects(n)
         except (NotImplementedError, SpecificationNotFound) as e:
             logger.warning(
-                "Skipping sanitiy checking generation for rule\n%s\n%s", self, e
+                "Skipping sanity checking generation for rule\n%s\n%s", self, e
             )
             return True
         self.subobjects = tempobjects
@@ -1141,5 +1141,5 @@ class VerificationRule(AbstractRule[CombinatorialClassType, CombinatorialObjectT
         try:
             return self.get_terms(n) == self.comb_class.get_terms(n)
         except (NotImplementedError, SpecificationNotFound) as e:
-            logger.warning("Skipping sanitiy checking counts for rule\n%s\n%s", self, e)
+            logger.warning("Skipping sanity checking counts for rule\n%s\n%s", self, e)
             return True

--- a/comb_spec_searcher/strategies/rule.py
+++ b/comb_spec_searcher/strategies/rule.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 from logzero import logger
-from sympy import Eq, Function
+from sympy import Eq, Function, var
 
 from comb_spec_searcher.combinatorial_class import CombinatorialClass
 from comb_spec_searcher.typing import (
@@ -41,7 +41,7 @@ from comb_spec_searcher.typing import (
 )
 
 from ..combinatorial_class import CombinatorialClassType, CombinatorialObjectType
-from ..exception import SanityCheckFailure, StrategyDoesNotApply
+from ..exception import SanityCheckFailure, SpecificationNotFound, StrategyDoesNotApply
 from ..utils import TermsCache
 from .constructor import Complement, Constructor, DisjointUnion
 
@@ -535,7 +535,11 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         actual_terms = self.comb_class.get_terms(n)
         temp_subterms = self.subterms
         self.subterms = tuple(child.get_terms for child in self.children)
-        rule_terms = self.get_terms(n)
+        try:
+            rule_terms = self.get_terms(n)
+        except (NotImplementedError, SpecificationNotFound) as e:
+            logger.warning(f"Skipping sanitiy checking counts for rule\n{self}\n{e}")
+            return True
         self.subterms = temp_subterms
         if actual_terms != rule_terms:
             raise SanityCheckFailure(
@@ -558,8 +562,10 @@ class Rule(AbstractRule[CombinatorialClassType, CombinatorialObjectType]):
         self.subobjects = tuple(child.get_objects for child in self.children)
         try:
             rule_objects = self.get_objects(n)
-        except NotImplementedError:
-            # Skipping testing rules that have not implemented object generation.
+        except (NotImplementedError, SpecificationNotFound) as e:
+            logger.warning(
+                f"Skipping sanitiy checking generation for rule\n{self}\n{e}"
+            )
             return True
         self.subobjects = tempobjects
         actual_objects = self.comb_class.get_objects(n)
@@ -1115,7 +1121,10 @@ class VerificationRule(AbstractRule[CombinatorialClassType, CombinatorialObjectT
         funcs: Optional[Dict[CombinatorialClassType, Function]] = None,
     ) -> Eq:
         lhs_func = get_function(self.comb_class)
-        return Eq(lhs_func, self.strategy.get_genf(self.comb_class, funcs))
+        return Eq(
+            lhs_func,
+            self.strategy.get_genf(self.comb_class, funcs).subs({var("F"): lhs_func}),
+        )
 
     @staticmethod
     def get_eq_symbol() -> str:
@@ -1129,4 +1138,8 @@ class VerificationRule(AbstractRule[CombinatorialClassType, CombinatorialObjectT
         )
 
     def sanity_check(self, n: int) -> bool:
-        return self.get_terms(n) == self.comb_class.get_terms(n)
+        try:
+            return self.get_terms(n) == self.comb_class.get_terms(n)
+        except (NotImplementedError, SpecificationNotFound) as e:
+            logger.warning(f"Skipping sanitiy checking counts for rule\n{self}\n{e}")
+            return True


### PR DESCRIPTION
Added a more verbose logging of the warning when rules are skipped. 