### PR TITLE
Improve Specifation.expand_verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrated from setup.py to modern pyproject.toml packaging with hatchling backend
 - Updated GitHub Actions workflows to use latest versions and modern build commands
 - Updated README badges: replaced deprecated Travis CI and requires.io badges with GitHub Actions
+- `CombinatorialSpecification.expand_verified` will expand all classes that use the same pack at once
 
 ### Removed
 - setup.py and MANIFEST.in files (replaced by pyproject.toml configuration)

--- a/comb_spec_searcher/comb_spec_searcher.py
+++ b/comb_spec_searcher/comb_spec_searcher.py
@@ -237,7 +237,7 @@ class CombinatorialSpecificationSearcher(Generic[CombinatorialClassType]):
                 logger.debug(
                     "The equivalence strategy %s returned the same "
                     "combinatorial class when applied to %r",
-                    str(rule).split(" ")[1],
+                    rule.formal_step,
                     comb_class,
                 )
                 continue

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -234,12 +234,8 @@ class CombinatorialSpecification(
         from .rule_db import RuleDBForest
 
         classes_to_expand: set[CombinatorialClassType] = set(
-            (
-                self.get_comb_class(comb_class)
-                if isinstance(comb_class, int)
-                else comb_class
-            )
-            for comb_class in comb_classes
+            (self.get_comb_class(cc) if isinstance(cc, int) else cc)
+            for cc in comb_classes
         )
         spec_rules: List[AbstractRule] = []
         for cc, rule in self.rules_dict.items():
@@ -259,9 +255,11 @@ class CombinatorialSpecification(
             expand_verified=continue_expanding_verified,
         )
         for rule in spec_rules:
-            start_label = css.classdb.get_label(rule.comb_class)
-            end_labels = tuple(map(css.classdb.get_label, rule.children))
-            ruledb.add(start_label, end_labels, rule)
+            ruledb.add(
+                css.classdb.get_label(rule.comb_class),
+                tuple(map(css.classdb.get_label, rule.children)),
+                rule,
+            )
         ruledb.reverse = reverse
         css.classqueue = DefaultQueue(css.strategy_pack)
         for comb_class in classes_to_expand:
@@ -271,10 +269,12 @@ class CombinatorialSpecification(
         # logger.info(CSS.run_information())
         try:
             # pylint: disable=protected-access
-            spec_rule = css._auto_search_rules(max_expansion_time=max_expansion_time)
+            new_spec_rules = css._auto_search_rules(
+                max_expansion_time=max_expansion_time
+            )
         except SpecificationNotFound as e:
             raise SpecificationNotFound("Expansion unsuccessful") from e
-        new_spec = CombinatorialSpecification(self.root, spec_rule)
+        new_spec = CombinatorialSpecification(self.root, new_spec_rules)
         return new_spec
 
     def _is_valid_spec(self) -> bool:

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -233,7 +233,7 @@ class CombinatorialSpecification(
         from .comb_spec_searcher import CombinatorialSpecificationSearcher
         from .rule_db import RuleDBForest
 
-        comb_classes = set(
+        classes_to_expand: set[CombinatorialClassType] = set(
             (
                 self.get_comb_class(comb_class)
                 if isinstance(comb_class, int)
@@ -243,7 +243,7 @@ class CombinatorialSpecification(
         )
         spec_rules: List[AbstractRule] = []
         for cc, rule in self.rules_dict.items():
-            if isinstance(rule, VerificationRule) and cc in comb_classes:
+            if isinstance(rule, VerificationRule) and cc in classes_to_expand:
                 continue
             if isinstance(rule, EquivalencePathRule):
                 spec_rules.extend(map(copy, rule.rules))
@@ -264,7 +264,7 @@ class CombinatorialSpecification(
             ruledb.add(start_label, end_labels, rule)
         ruledb.reverse = reverse
         css.classqueue = DefaultQueue(css.strategy_pack)
-        for comb_class in comb_classes:
+        for comb_class in classes_to_expand:
             label_to_expand = css.classdb.get_label(comb_class)
             css.classqueue.add(label_to_expand)
             css.try_verify(comb_class, label_to_expand)

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -161,18 +161,28 @@ class CombinatorialSpecification(
             rule = new_spec.rules_dict[class_to_expand]
             assert isinstance(rule, VerificationRule)
             pack = rule.pack()
+            classes_to_expand = set(
+                cc
+                for cc in new_spec.unexpanded_verified_classes()
+                if new_spec.rules_dict[cc].strategy == rule.strategy
+            )
             try:
-                logger.info("Expanding with %s on \n%s\n", pack.name, class_to_expand)
-                new_spec = new_spec.expand_comb_class(
+                logger.info(
+                    "Expanding with %s on \n%s\nand %s other classes",
+                    pack.name,
                     class_to_expand,
+                    len(classes_to_expand),
+                )
+                new_spec = new_spec.expand_comb_classes(
+                    classes_to_expand,
                     pack,
                     reverse=False,
                     continue_expanding_verified=False,
                 )
             except SpecificationNotFound:
                 logger.info("Specification NOT detected. Allowing reverse rules")
-                new_spec = new_spec.expand_comb_class(
-                    class_to_expand,
+                new_spec = new_spec.expand_comb_classes(
+                    classes_to_expand,
                     pack,
                     reverse=True,
                     continue_expanding_verified=True,

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -199,6 +199,18 @@ class CombinatorialSpecification(
         continue_expanding_verified: bool,
         max_expansion_time: Optional[float] = None,
     ) -> "CombinatorialSpecification[CombinatorialClassType, CombinatorialObjectType]":
+        return self.expand_comb_classes(
+            [comb_class, pack, reverse, continue_expanding_verified, max_expansion_time]
+        )
+
+    def expand_comb_classes(
+        self,
+        comb_classes: Iterable[Union[int, CombinatorialClassType]],
+        pack: StrategyPack,
+        reverse: bool,
+        continue_expanding_verified: bool,
+        max_expansion_time: Optional[float] = None,
+    ) -> "CombinatorialSpecification[CombinatorialClassType, CombinatorialObjectType]":
         """
         Will try to expand a particular class with respect to the given strategy pack.
 
@@ -211,12 +223,18 @@ class CombinatorialSpecification(
         from .comb_spec_searcher import CombinatorialSpecificationSearcher
         from .rule_db import RuleDBForest
 
-        if isinstance(comb_class, int):
-            comb_class = self.get_comb_class(comb_class)
+        comb_classes = set(
+            (
+                self.get_comb_class(comb_class)
+                if isinstance(comb_class, int)
+                else comb_class
+            )
+            for comb_class in comb_classes
+        )
 
         spec_rules: List[AbstractRule] = []
         for cc, rule in self.rules_dict.items():
-            if cc != comb_class:
+            if cc in comb_classes:
                 if isinstance(rule, EquivalencePathRule):
                     spec_rules.extend(map(copy, rule.rules))
                 else:
@@ -236,9 +254,10 @@ class CombinatorialSpecification(
             ruledb.add(start_label, end_labels, rule)
         ruledb.reverse = reverse
         css.classqueue = DefaultQueue(css.strategy_pack)
-        label_to_expand = css.classdb.get_label(comb_class)
-        css.classqueue.add(label_to_expand)
-        css.try_verify(comb_class, label_to_expand)
+        for comb_class in comb_classes:
+            label_to_expand = css.classdb.get_label(comb_class)
+            css.classqueue.add(label_to_expand)
+            css.try_verify(comb_class, label_to_expand)
         # logger.info(CSS.run_information())
         try:
             # pylint: disable=protected-access

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -200,7 +200,7 @@ class CombinatorialSpecification(
         max_expansion_time: Optional[float] = None,
     ) -> "CombinatorialSpecification[CombinatorialClassType, CombinatorialObjectType]":
         return self.expand_comb_classes(
-            [comb_class, pack, reverse, continue_expanding_verified, max_expansion_time]
+            [comb_class], pack, reverse, continue_expanding_verified, max_expansion_time
         )
 
     def expand_comb_classes(

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -231,14 +231,14 @@ class CombinatorialSpecification(
             )
             for comb_class in comb_classes
         )
-
         spec_rules: List[AbstractRule] = []
         for cc, rule in self.rules_dict.items():
-            if cc in comb_classes:
-                if isinstance(rule, EquivalencePathRule):
-                    spec_rules.extend(map(copy, rule.rules))
-                else:
-                    spec_rules.append(copy(rule))
+            if isinstance(rule, VerificationRule) and cc in comb_classes:
+                continue
+            if isinstance(rule, EquivalencePathRule):
+                spec_rules.extend(map(copy, rule.rules))
+            else:
+                spec_rules.append(copy(rule))
 
         ruledb = RuleDBForest(reverse=False, rule_cache=spec_rules)
         css = CombinatorialSpecificationSearcher(

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -171,7 +171,7 @@ class CombinatorialSpecification(
                     "Expanding with %s on \n%s\nand %s other classes",
                     pack.name,
                     class_to_expand,
-                    len(classes_to_expand),
+                    len(classes_to_expand) - 1,
                 )
                 new_spec = new_spec.expand_comb_classes(
                     classes_to_expand,

--- a/comb_spec_searcher/specification.py
+++ b/comb_spec_searcher/specification.py
@@ -161,11 +161,12 @@ class CombinatorialSpecification(
             rule = new_spec.rules_dict[class_to_expand]
             assert isinstance(rule, VerificationRule)
             pack = rule.pack()
-            classes_to_expand = set(
-                cc
-                for cc in new_spec.unexpanded_verified_classes()
-                if new_spec.rules_dict[cc].strategy == rule.strategy
-            )
+            classes_to_expand = set()
+            for cc in new_spec.unexpanded_verified_classes():
+                other_rule = new_spec.rules_dict[cc]
+                if isinstance(other_rule, VerificationRule):
+                    if rule.pack() == other_rule.pack():
+                        classes_to_expand.add(cc)
             try:
                 logger.info(
                     "Expanding with %s on \n%s\nand %s other classes",


### PR DESCRIPTION
When expanding verified classes, expand all comb_classes that use the same strategy pack at once. This prevents us needing to use the expensive minimise code as often in the forest searcher. 

(Also sneaking in a debug print that was not displaying the information we want it to)